### PR TITLE
Update test tube positioning and rename to 20mL Test Tube

### DIFF
--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -34,7 +34,12 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
       return <Beaker className="w-8 h-8" />;
     };
     const slug = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-');
-    return experiment.equipment.map((name) => ({ id: slug(name), name, icon: iconFor(name) }));
+    return experiment.equipment.map((name) => {
+      const key = name.toLowerCase();
+      const baseId = slug(name);
+      const id = key.includes('test tube') ? 'test-tube' : baseId;
+      return { id, name, icon: iconFor(name) };
+    });
   }, [experiment.equipment]);
 
   const getPosition = (id: string) => {

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -56,7 +56,7 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
     const item = items.find(i => i.id === id);
     if (!item) return;
     if (!equipmentOnBench.find(e => e.id === id)) {
-      setEquipmentOnBench(prev => [...prev, { id, name: item.name, position: getPosition(id) }]);
+      setEquipmentOnBench(prev => [...prev, { id, name: id === 'test-tube' ? '20 mL Test Tube' : item.name, position: getPosition(id) }]);
       if (!completedSteps.includes(currentStep)) onStepComplete(currentStep);
     }
   };
@@ -102,7 +102,7 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
               </h3>
               <div className="space-y-3">
                 {items.map((eq) => (
-                  <PHEquipment key={eq.id} id={eq.id} name={eq.name} icon={eq.icon} disabled={!experimentStarted} />
+                  <PHEquipment key={eq.id} id={eq.id} name={eq.id === 'test-tube' ? '20 mL Test Tube' : eq.name} icon={eq.icon} disabled={!experimentStarted} />
                 ))}
               </div>
               <div className="mt-4 p-3 bg-blue-50 rounded-lg">

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -46,6 +46,9 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
     const idx = items.findIndex(i => i.id === id);
     const baseX = 220; // center column
     const baseY = 160;
+    if (id === 'test-tube') {
+      return { x: baseX, y: baseY + 140 };
+    }
     return { x: baseX + ((idx % 2) * 160 - 80), y: baseY + Math.floor(idx / 2) * 140 };
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "code",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Purpose
The user requested modifications to the test tube component for their ethanoic acid buffer experiment. They wanted to:
- Add a test tube similar to the one used in the HCl/CH3COOH pH comparison experiment
- Lower the test tube position on the virtual lab bench
- Rename the test tube to "20mL Test Tube" for better clarity

## Code changes
- **Equipment positioning**: Added special positioning logic for test tubes, placing them lower on the bench (y-offset +140)
- **Equipment naming**: Updated test tube display name to "20mL Test Tube" in both the equipment list and when placed on bench
- **ID mapping**: Added logic to standardize test tube IDs to 'test-tube' regardless of original name variations
- **Package lock**: Added empty package-lock.json fileTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/07109eb181aa470eadf68d6697a440cb/nova-lab)

👀 [Preview Link](https://07109eb181aa470eadf68d6697a440cb-nova-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>07109eb181aa470eadf68d6697a440cb</projectId>-->
<!--<branchName>nova-lab</branchName>-->