### PR TITLE
Add View RESULTS button and equipment click interaction

### DIFF
--- a/chemLab2-main/client/src/experiments/PHComparison/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/PHComparison/components/Equipment.tsx
@@ -74,6 +74,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
           <div
             draggable={!disabled}
             onDragStart={handleDragStart}
+            onClick={() => { if (onInteract) onInteract(id); }}
             className={`flex flex-col items-center p-4 rounded-lg border-2 ${
               disabled ? 'border-gray-200 bg-gray-50 opacity-50' : 'border-gray-300 bg-white hover:border-blue-400 hover:shadow-lg'
             }`}

--- a/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -351,8 +351,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
               <Button onClick={() => { setEquipmentOnBench([]); setTestTube(INITIAL_TESTTUBE); setHistory([]); onReset(); }} variant="outline" className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100">Reset Experiment</Button>
 
               {(analysisLog.length > 0 || hclSample || aceticSample || compareMode) && (
-                <Button onClick={() => setShowResultsModal(true)} className="w-full bg-emerald-600 hover:bg-emerald-700 text-white mt-2 flex items-center justify-center">
-
+                <Button onClick={() => setShowResultsModal(true)} className="w-full bg-white border-gray-200 text-gray-700 hover:bg-gray-100 mt-2 flex items-center justify-center">
                   <span>View RESULTS</span>
                 </Button>
               )}

--- a/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -336,7 +336,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
               </h3>
               <div className="space-y-3">
                 {PH_LAB_EQUIPMENT.map((eq) => (
-                  <Equipment key={eq.id} id={eq.id} name={eq.name} icon={eq.icon} disabled={!experimentStarted} />
+                  <Equipment key={eq.id} id={eq.id} name={eq.name} icon={eq.icon} disabled={!experimentStarted} onInteract={handleInteract} />
                 ))}
               </div>
               <div className="mt-4 p-3 bg-blue-50 rounded-lg">

--- a/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -349,6 +349,13 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                 <Undo2 className="w-4 h-4 mr-2" /> UNDO
               </Button>
               <Button onClick={() => { setEquipmentOnBench([]); setTestTube(INITIAL_TESTTUBE); setHistory([]); onReset(); }} variant="outline" className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100">Reset Experiment</Button>
+
+              {(analysisLog.length > 0 || hclSample || aceticSample || compareMode) && (
+                <Button onClick={() => setShowResultsModal(true)} className="w-full bg-emerald-600 hover:bg-emerald-700 text-white mt-2 flex items-center justify-center">
+
+                  <span>View RESULTS</span>
+                </Button>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Purpose
The user requested to add a "View RESULTS" button below the reset button that appears after results are generated, remove the green color styling from the button, and enable clicking on the 0.1 M Ethanoic (Acetic) Acid bottle to show a specific interface.

## Code changes
- **Equipment component**: Added `onClick` handler to enable equipment interaction when clicked
- **VirtualLab component**: 
  - Added `onInteract` prop to Equipment components to handle click interactions
  - Added conditional "View RESULTS" button that appears when analysis results are available
  - Button uses neutral styling (white background, gray text/border) instead of green
  - Button is positioned below the reset button and triggers the results modalTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/07109eb181aa470eadf68d6697a440cb/orbit-sanctuary)

👀 [Preview Link](https://07109eb181aa470eadf68d6697a440cb-orbit-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>07109eb181aa470eadf68d6697a440cb</projectId>-->
<!--<branchName>orbit-sanctuary</branchName>-->