### PR TITLE
Add analytical balance image display for oxalic acid step 1

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -13,6 +13,7 @@ interface EquipmentProps {
   id: string;
   name: string;
   icon: React.ReactNode;
+  typeId?: string;
   imageSrc?: string;
   onDrag?: (id: string, x: number, y: number) => void;
   position: { x: number; y: number } | null;
@@ -37,6 +38,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
   id,
   name,
   icon,
+  typeId,
   imageSrc,
   onDrag,
   position,
@@ -111,8 +113,9 @@ export const Equipment: React.FC<EquipmentProps> = ({
 
   const getEquipmentContent = () => {
     const totalVolume = chemicals.reduce((sum, chemical) => sum + chemical.amount, 0);
-    
-    switch (id) {
+    const eqId = typeId ?? id;
+
+    switch (eqId) {
       case "analytical_balance":
         const oxalicAcid = chemicals.find(c => c.id === "oxalic_acid");
         return (
@@ -132,7 +135,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             </div>
           </div>
         );
-        
+
       case "volumetric_flask":
         const isAtMark = preparationState?.finalVolume;
         const isNearMark = preparationState?.nearMark;
@@ -142,7 +145,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             <div className="text-xs space-y-1">
               <div>250 mL</div>
               {chemicals.length > 0 && (
-                <div 
+                <div
                   className="w-6 h-8 mx-auto rounded-b-full border"
                   style={{
                     backgroundColor: chemicals[0]?.color || "#87CEEB",
@@ -214,7 +217,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
   };
 
   const canAcceptChemical = (chemicalId: string) => {
-    switch (id) {
+    const eqId = typeId ?? id;
+    switch (eqId) {
       case "analytical_balance":
         return chemicalId === "oxalic_acid";
       case "beaker":
@@ -227,7 +231,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
   };
 
   const getActionButton = () => {
-    switch (id) {
+    const eqId = typeId ?? id;
+    switch (eqId) {
       case "analytical_balance":
         if (chemicals.some(c => c.id === "oxalic_acid")) {
           return (

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -13,6 +13,7 @@ interface EquipmentProps {
   id: string;
   name: string;
   icon: React.ReactNode;
+  imageSrc?: string;
   onDrag?: (id: string, x: number, y: number) => void;
   position: { x: number; y: number } | null;
   chemicals?: Array<{
@@ -36,6 +37,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
   id,
   name,
   icon,
+  imageSrc,
   onDrag,
   position,
   chemicals = [],
@@ -115,7 +117,11 @@ export const Equipment: React.FC<EquipmentProps> = ({
         const oxalicAcid = chemicals.find(c => c.id === "oxalic_acid");
         return (
           <div className="text-center">
-            <Scale className="w-8 h-8 mx-auto mb-2 text-gray-600" />
+            {imageSrc ? (
+              <img src={imageSrc} alt={name} className="w-20 h-20 mx-auto mb-2 object-contain" />
+            ) : (
+              <Scale className="w-8 h-8 mx-auto mb-2 text-gray-600" />
+            )}
             <div className="text-xs space-y-1">
               <div>Digital Display</div>
               {oxalicAcid && (

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -301,12 +301,20 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
 
               // If this position corresponds to a known equipment, render normally
               if (equipmentData) {
+                // Show the provided analytical balance image when in step 1 of the Oxalic Acid preparation
+                const balanceImageUrl = "https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2F52221253b4e74677842e5d59914ce1f5?format=webp&width=800";
+                const shouldShowBalanceImage =
+                  equipmentData.id === "analytical_balance" &&
+                  step.id === 1 &&
+                  experimentTitle === "Preparation of Standard Solution of Oxalic Acid";
+
                 return (
                   <Equipment
                     key={position.id}
                     id={position.id}
                     name={equipmentData.name}
                     icon={equipmentData.icon}
+                    imageSrc={shouldShowBalanceImage ? balanceImageUrl : undefined}
                     onDrag={handleEquipmentDrag}
                     position={{ x: position.x, y: position.y }}
                     chemicals={position.chemicals}

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -312,6 +312,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                   <Equipment
                     key={position.id}
                     id={position.id}
+                    typeId={equipmentData.id}
                     name={equipmentData.name}
                     icon={equipmentData.icon}
                     imageSrc={shouldShowBalanceImage ? balanceImageUrl : undefined}
@@ -340,6 +341,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                   <Equipment
                     key={position.id}
                     id={position.id}
+                    typeId={chem.id}
                     name={`${chem.name} Bottle`}
                     icon={bottleIcon}
                     onDrag={handleEquipmentDrag}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,14 @@
 {
-  "name": "code",
+  "name": "chem-lab-monorepo",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "chem-lab-monorepo",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "MIT"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "chem-lab-monorepo",
+  "private": true,
+  "version": "1.0.0",
+  "license": "MIT",
+  "scripts": {
+    "postinstall": "npm --prefix chemLab2-main install",
+    "dev": "npm --prefix chemLab2-main run dev",
+    "start": "npm --prefix chemLab2-main start",
+    "build": "npm --prefix chemLab2-main run build",
+    "check": "npm --prefix chemLab2-main run check"
+  }
+}


### PR DESCRIPTION
## Purpose

The user requested that when dragging and dropping the analytical balance into the workspace during step 1 of the "Preparation of Standard Solution of Oxalic Acid" experiment, a specific image should be displayed instead of the default icon. After the initial request, the user confirmed that nothing had changed and requested implementation.

## Code changes

- **Equipment component**: Added optional `typeId` and `imageSrc` props to support custom equipment identification and image display
- **Analytical balance rendering**: Modified to conditionally display a custom image when `imageSrc` is provided, falling back to the default Scale icon
- **WorkBench component**: Added logic to show a specific analytical balance image URL when the equipment is an analytical balance, the current step is 1, and the experiment is "Preparation of Standard Solution of Oxalic Acid"
- **Equipment identification**: Updated equipment matching logic to use `typeId` when available, allowing for more flexible equipment type handling
- **Package configuration**: Added root-level package.json for monorepo management with scripts to handle the chemLab2-main subdirectoryTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/07109eb181aa470eadf68d6697a440cb/nova-haven)

👀 [Preview Link](https://07109eb181aa470eadf68d6697a440cb-nova-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>07109eb181aa470eadf68d6697a440cb</projectId>-->
<!--<branchName>nova-haven</branchName>-->