### PR TITLE
Add blinking UI cues for measure and reset buttons

### DIFF
--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -387,13 +387,13 @@ const stepsProgress = (
                 (() => {
                   const phItem = equipmentOnBench.find(e => e.id === 'universal-indicator' || e.id.toLowerCase().includes('ph'))!;
                   return (
-                    <div key="measure-button" style={{ position: 'absolute', left: phItem.position.x, top: phItem.position.y + 70, transform: 'translate(-50%, 0)' }}>
+                    <div key="measure-button" className="measure-button-wrapper" style={{ ['--left' as any]: `${phItem.position.x}px`, ['--top' as any]: `${phItem.position.y + 70}px` } as any}>
                       {(() => {
                         const paperHasColor = Boolean((phItem as any).color);
                         return (
                           <Button
                             size="sm"
-                            className={`bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${!paperHasColor ? 'animate-pulse' : ''}`}
+                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${paperHasColor ? 'blink-until-pressed' : ''}`}
                             onClick={() => {
                               if (!paperHasColor) {
                                 testPH();

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -432,7 +432,7 @@ const stepsProgress = (
                   <div key="reset-sodium" style={{ position: 'absolute', left: sodiumItem.position.x, top: sodiumItem.position.y + 150, transform: 'translate(-50%, 0)' }}>
                     <Button
                       size="sm"
-                      className="bg-red-500 text-white hover:bg-red-600 shadow-sm"
+                      className={`bg-red-500 text-white hover:bg-red-600 shadow-sm ${sodiumVolumeAdded > 0 ? 'blink-until-pressed' : ''}`}
                       onClick={() => {
                         // Reset sodium ethanoate state but keep the sodium bottle on the bench
                         // Revert any volume previously added by sodium ethanoate

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -213,8 +213,8 @@ const confirmAddSodium = () => {
   const nextAdditions = sodiumAdditions + 1;
   setSodiumAdditions(nextAdditions);
   if (nextAdditions >= 2) setShouldBlinkReset(false);
-  // prompt user to measure after adding sodium ethanoate
-  setShouldBlinkMeasure(true);
+  // prompt user to measure after adding sodium ethanoate (only if fewer than 3 total measurements so far)
+  setShouldBlinkMeasure(measurementVersion < 3);
 
   // compute and store pH after sodium ethanoate addition
   const totalVolL = Math.max(1e-6, newTestTubeVolume / 1000);

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -45,6 +45,8 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
   // Guided UI cues
   const [shouldBlinkMeasure, setShouldBlinkMeasure] = useState(false);
   const [shouldBlinkReset, setShouldBlinkReset] = useState(false);
+  // Count how many times sodium ethanoate has been added this session
+  const [sodiumAdditions, setSodiumAdditions] = useState(0);
 
   const [showAceticDialog, setShowAceticDialog] = useState(false);
   const [aceticVolume, setAceticVolume] = useState("10.0");
@@ -207,6 +209,10 @@ const confirmAddSodium = () => {
   setSodiumMoles(newSodiumMoles);
   // track cumulative sodium volume added so Reset can revert the volume
   setSodiumVolumeAdded(prev => Math.max(0, prev + v));
+  // bump additions count; if this is the 2nd (or later) addition, ensure reset won't blink anymore
+  const nextAdditions = sodiumAdditions + 1;
+  setSodiumAdditions(nextAdditions);
+  if (nextAdditions >= 2) setShouldBlinkReset(false);
   // prompt user to measure after adding sodium ethanoate
   setShouldBlinkMeasure(true);
 
@@ -319,8 +325,9 @@ function testPH() {
 
   // stop prompting MEASURE (we just measured)
   setShouldBlinkMeasure(false);
-  // after measuring, prompt to reset sodium if any was added
-  if (sodiumVolumeAdded > 0) setShouldBlinkReset(true);
+  // after measuring, prompt to reset sodium if any was added and fewer than 2 additions so far
+  if (sodiumVolumeAdded > 0 && sodiumAdditions < 2) setShouldBlinkReset(true);
+  else setShouldBlinkReset(false);
   applyPHResult(ph);
 }
 

--- a/chemLab2-main/client/src/index.css
+++ b/chemLab2-main/client/src/index.css
@@ -255,3 +255,21 @@
 .stirring-rod-optimized:active {
   cursor: grabbing !important;
 }
+
+/* Measure button wrapper and blink animation */
+.measure-button-wrapper {
+  position: absolute;
+  left: var(--left);
+  top: var(--top);
+  transform: translate(-50%, 0);
+  z-index: 30;
+}
+
+.measure-action-btn.blink-until-pressed {
+  animation: blink 1s linear infinite;
+}
+
+@keyframes blink {
+  0%, 49% { opacity: 1; transform: scale(1); }
+  50%, 100% { opacity: 0; transform: scale(0.98); }
+}

--- a/chemLab2-main/client/src/index.css
+++ b/chemLab2-main/client/src/index.css
@@ -273,3 +273,8 @@
   0%, 49% { opacity: 1; transform: scale(1); }
   50%, 100% { opacity: 0; transform: scale(0.98); }
 }
+
+/* Generic blink utility */
+.blink-until-pressed {
+  animation: blink 1s linear infinite;
+}


### PR DESCRIPTION
## Purpose

The user wanted to implement guided UI cues to help users navigate the ethanoic buffer experiment workflow. Specifically, they requested:
- Blinking "MEASURE" button after sodium ethanoate is added to prompt pH measurement
- Blinking "reset sodium ethanoate" button after measurement to guide next steps
- Smart stopping conditions: stop blinking reset button after 2nd sodium addition, stop blinking measure button after 3rd measurement

## Code changes

- **State management**: Added `shouldBlinkMeasure`, `shouldBlinkReset`, and `sodiumAdditions` state variables to track UI cue conditions
- **Sodium addition logic**: Enhanced `confirmAddSodium()` to increment addition counter and trigger measure button blinking (with 3-measurement limit)
- **pH measurement logic**: Modified `testPH()` to stop measure blinking and conditionally start reset blinking based on addition count
- **Reset functionality**: Updated reset button to stop its own blinking when clicked
- **CSS animations**: Added `.blink-until-pressed` class with keyframe animation for visual blinking effect
- **Button styling**: Applied conditional blinking classes to both measure and reset buttons based on stateTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1241ca195be9431cb4572f0a0c3348c4/zenith-home)

👀 [Preview Link](https://1241ca195be9431cb4572f0a0c3348c4-zenith-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1241ca195be9431cb4572f0a0c3348c4</projectId>-->
<!--<branchName>zenith-home</branchName>-->