### PR TITLE
Hide equipment from palette after drag and drop

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -199,7 +199,7 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
             <CardContent>
               <h3 className="text-sm font-semibold text-gray-900 mb-3">Equipment</h3>
               <div className="grid grid-cols-2 gap-3 mb-4">
-                {OXALIC_ACID_EQUIPMENT.map((eq) => (
+                {OXALIC_ACID_EQUIPMENT.filter(eq => !usedEquipment.includes(eq.id)).map((eq) => (
                   <Equipment key={eq.id} id={eq.id} name={eq.name} icon={eq.icon} position={null} />
                 ))}
               </div>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -244,6 +244,7 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
               onUndoStep={handleUndoStep}
               onResetExperiment={handleResetExperiment}
               currentStepIndex={currentStep + 1}
+              onEquipmentPlaced={handleEquipmentPlaced}
             />
           </div>
         </div>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -22,6 +22,11 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
   const [timer, setTimer] = useState(0);
   const [experimentStarted, setExperimentStarted] = useState(false);
   const [resetKey, setResetKey] = useState(0);
+  const [usedEquipment, setUsedEquipment] = useState<string[]>([]);
+
+  const handleEquipmentPlaced = (id: string) => {
+    setUsedEquipment(prev => (prev.includes(id) ? prev : [...prev, id]));
+  };
 
   const experiment = OxalicAcidData;
   const [match, params] = useRoute("/experiment/:id");

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
@@ -26,6 +26,7 @@ import type {
 } from "../types";
 
 interface OxalicAcidVirtualLabProps {
+  onEquipmentPlaced?: (id: string) => void;
   step: ExperimentStep;
   onStepComplete: () => void;
   isActive: boolean;

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
@@ -382,6 +382,7 @@ function OxalicAcidVirtualLab({
           onUndoStep={onUndoStep}
           onResetExperiment={onResetExperiment}
           currentStepIndex={currentStepIndex}
+          onEquipmentPlaced={onEquipmentPlaced}
         />
       </div>
     </TooltipProvider>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
@@ -60,6 +60,7 @@ function OxalicAcidVirtualLab({
   onUndoStep,
   onResetExperiment,
   currentStepIndex,
+  onEquipmentPlaced,
 }: OxalicAcidVirtualLabProps) {
   const [equipmentPositions, setEquipmentPositions] = useState<
     EquipmentPosition[]

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -34,6 +34,7 @@ interface WorkBenchProps {
   results: Result[];
   chemicals: ChemicalType[];
   equipment: EquipmentType[];
+  onEquipmentPlaced?: (id: string) => void;
   onUndoStep: () => void;
   onResetExperiment: () => void;
   currentStepIndex: number;
@@ -146,18 +147,20 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
 
       if (data.id && data.name) {
         setEquipmentPositions(prev => [
-          ...prev,
-          {
-            id: `${data.id}_${Date.now()}`,
-            x: x - 50,
-            y: y - 50,
-            chemicals: [],
-            typeId: data.id,
-            name: data.name,
-            imageSrc: data.imageSrc,
-          }
-        ]);
-        return;
+        ...prev,
+        {
+          id: `${data.id}_${Date.now()}`,
+          x: x - 50,
+          y: y - 50,
+          chemicals: [],
+          typeId: data.id,
+          name: data.name,
+          imageSrc: data.imageSrc,
+        }
+      ]);
+      // Notify parent that this equipment was placed so it can be removed from the palette
+      if (onEquipmentPlaced) onEquipmentPlaced(data.id);
+      return;
       }
     }
 
@@ -185,18 +188,20 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
       const eq = equipment.find(eqp => eqp.id === trimmed);
       if (eq) {
         setEquipmentPositions(prev => [
-          ...prev,
-          {
-            id: `${eq.id}_${Date.now()}`,
-            x: x - 50,
-            y: y - 50,
-            chemicals: [],
-            typeId: eq.id,
-            name: eq.name,
-            imageSrc: undefined,
-          }
-        ]);
-        return;
+        ...prev,
+        {
+          id: `${eq.id}_${Date.now()}`,
+          x: x - 50,
+          y: y - 50,
+          chemicals: [],
+          typeId: eq.id,
+          name: eq.name,
+          imageSrc: undefined,
+        }
+      ]);
+      // Notify parent that this equipment was placed (hide from palette)
+      if (onEquipmentPlaced) onEquipmentPlaced(eq.id);
+      return;
       }
 
       // Try chemicals list


### PR DESCRIPTION
## Purpose
The user requested to remove equipment icons from the equipment palette after they are dragged and dropped onto the workbench during the oxalic acid experiment preparation. This improves the user experience by preventing duplicate equipment placement and providing visual feedback that equipment has been used.

## Code changes
- Added `usedEquipment` state array to track placed equipment IDs
- Added `handleEquipmentPlaced` callback function to update the used equipment list
- Modified equipment rendering to filter out equipment that has already been placed
- Passed the `onEquipmentPlaced` callback through the component hierarchy (OxalicAcidApp → VirtualLab → WorkBench)
- Updated WorkBench drop handlers to notify parent components when equipment is placed on the workbenchTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 29`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1241ca195be9431cb4572f0a0c3348c4/vibe-space)

👀 [Preview Link](https://1241ca195be9431cb4572f0a0c3348c4-vibe-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1241ca195be9431cb4572f0a0c3348c4</projectId>-->
<!--<branchName>vibe-space</branchName>-->