### PR TITLE
Fix equipment drag behavior and update equipment list

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -130,6 +130,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
                     ? "mx-auto block h-[22rem] w-auto object-contain"
                     : "w-20 h-20 mx-auto mb-2 object-contain"
                 }
+                draggable={false}
+                onDragStart={(e) => e.preventDefault()}
               />
             ) : (
               <Scale className={isAnalytical && position ? "w-12 h-12 mx-auto mb-2 text-gray-600" : "w-8 h-8 mx-auto mb-2 text-gray-600"} />
@@ -218,7 +220,13 @@ export const Equipment: React.FC<EquipmentProps> = ({
         return (
           <div className="text-center">
             {imageSrc ? (
-              <img src={imageSrc} alt={name} className="w-24 h-24 mx-auto mb-2 object-contain" />
+              <img
+                src={imageSrc}
+                alt={name}
+                className="w-24 h-24 mx-auto mb-2 object-contain"
+                draggable={false}
+                onDragStart={(e) => e.preventDefault()}
+              />
             ) : (
               icon
             )}

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -119,20 +119,32 @@ export const Equipment: React.FC<EquipmentProps> = ({
     switch (eqId) {
       case "analytical_balance":
         const oxalicAcid = chemicals.find(c => c.id === "oxalic_acid");
+        // When the analytical balance is placed on the workbench, hide the visual icon/image
+        // but preserve any numeric readout / actions via the action button below.
+        if (position) {
+          return (
+            <div className="text-center">
+              {oxalicAcid && (
+                <div className="mt-2 text-xs">
+                  <div className="bg-black text-green-400 px-2 py-1 rounded font-mono inline-block">
+                    {(oxalicAcid.amount / 1000).toFixed(4)} g
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        }
+
         return (
           <div className="text-center">
             {imageSrc ? (
               <img
                 src={imageSrc}
                 alt={name}
-                className={
-                  isAnalytical && position
-                    ? "mx-auto block h-[22rem] w-auto object-contain"
-                    : "w-20 h-20 mx-auto mb-2 object-contain"
-                }
+                className={"w-20 h-20 mx-auto mb-2 object-contain"}
               />
             ) : (
-              <Scale className={isAnalytical && position ? "w-12 h-12 mx-auto mb-2 text-gray-600" : "w-8 h-8 mx-auto mb-2 text-gray-600"} />
+              <Scale className={"w-8 h-8 mx-auto mb-2 text-gray-600"} />
             )}
             {oxalicAcid && (
               <div className="mt-2 text-xs">

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -119,32 +119,20 @@ export const Equipment: React.FC<EquipmentProps> = ({
     switch (eqId) {
       case "analytical_balance":
         const oxalicAcid = chemicals.find(c => c.id === "oxalic_acid");
-        // When the analytical balance is placed on the workbench, hide the visual icon/image
-        // but preserve any numeric readout / actions via the action button below.
-        if (position) {
-          return (
-            <div className="text-center">
-              {oxalicAcid && (
-                <div className="mt-2 text-xs">
-                  <div className="bg-black text-green-400 px-2 py-1 rounded font-mono inline-block">
-                    {(oxalicAcid.amount / 1000).toFixed(4)} g
-                  </div>
-                </div>
-              )}
-            </div>
-          );
-        }
-
         return (
           <div className="text-center">
             {imageSrc ? (
               <img
                 src={imageSrc}
                 alt={name}
-                className={"w-20 h-20 mx-auto mb-2 object-contain"}
+                className={
+                  isAnalytical && position
+                    ? "mx-auto block h-[22rem] w-auto object-contain"
+                    : "w-20 h-20 mx-auto mb-2 object-contain"
+                }
               />
             ) : (
-              <Scale className={"w-8 h-8 mx-auto mb-2 text-gray-600"} />
+              <Scale className={isAnalytical && position ? "w-12 h-12 mx-auto mb-2 text-gray-600" : "w-8 h-8 mx-auto mb-2 text-gray-600"} />
             )}
             {oxalicAcid && (
               <div className="mt-2 text-xs">

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -199,7 +199,7 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
             <CardContent>
               <h3 className="text-sm font-semibold text-gray-900 mb-3">Equipment</h3>
               <div className="grid grid-cols-2 gap-3 mb-4">
-                {OXALIC_ACID_EQUIPMENT.filter(eq => !usedEquipment.includes(eq.id)).map((eq) => (
+                {OXALIC_ACID_EQUIPMENT.filter(eq => (eq.id === 'analytical_balance') || !usedEquipment.includes(eq.id)).map((eq) => (
                   <Equipment key={eq.id} id={eq.id} name={eq.name} icon={eq.icon} position={null} />
                 ))}
               </div>

--- a/chemLab2-main/data/experiments.json
+++ b/chemLab2-main/data/experiments.json
@@ -559,10 +559,6 @@
       "Beakers",
       "Test Tubes",
       "pH Meter or Universal Indicator",
-      "Dropper Pipettes",
-      "Stirring Rod",
-      "Volumetric Flask",
-      "Burette (optional)",
       "Ammonium hydroxide solution (0.1 M NH4OH)",
       "Ammonium chloride solution (NH4Cl)"
     ],

--- a/chemLab2-main/data/experiments.json
+++ b/chemLab2-main/data/experiments.json
@@ -562,7 +562,9 @@
       "Dropper Pipettes",
       "Stirring Rod",
       "Volumetric Flask",
-      "Burette (optional)"
+      "Burette (optional)",
+      "Ammonium hydroxide solution (0.1 M NH4OH)",
+      "Ammonium chloride solution (NH4Cl)"
     ],
     "stepDetails": [
       { "id": 1, "title": "Prepare 0.1 M NH4OH Solution", "description": "Prepare approximately 100 mL of 0.1 M ammonium hydroxide solution (NH4OH) using dilute ammonia solution. Record initial concentration and temperature.", "duration": "5 minutes", "completed": false },


### PR DESCRIPTION
## Purpose
The user requested several equipment-related improvements for the chemistry lab interface:
- Remove specific equipment items (dropper pipettes, stirring rod, volumetric flask, burette) from the equipment section
- Fix analytical balance behavior to remain visible in equipment section after dragging to workspace
- Prevent unwanted drag icons from appearing in the workspace after equipment is placed

## Code changes
- **Equipment.tsx**: Added `draggable={false}` and `onDragStart` prevention to equipment images to disable unwanted drag behavior
- **OxalicAcidApp.tsx**: Modified equipment filtering logic to always show analytical balance in equipment section regardless of usage status
- **experiments.json**: Updated equipment list by removing dropper pipettes, stirring rod, volumetric flask, and burette; added ammonium hydroxide and ammonium chloride solutions insteadTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 34`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1241ca195be9431cb4572f0a0c3348c4/zenith-landing)

👀 [Preview Link](https://1241ca195be9431cb4572f0a0c3348c4-zenith-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1241ca195be9431cb4572f0a0c3348c4</projectId>-->
<!--<branchName>zenith-landing</branchName>-->