### PR TITLE
Add NH4OH and NH4Cl solution positions to VirtualLab

### DIFF
--- a/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -104,6 +104,8 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
     const positions: Record<string, { x: number; y: number }> = {
       'test-tube': { x: 200, y: 250 },
       'hcl-0-01m': { x: 500, y: 200 },
+      'nh4oh-0-1m': { x: 540, y: 200 },
+      'nh4cl-0-1m': { x: 540, y: 320 },
       'acetic-0-01m': { x: 500, y: 360 },
       'universal-indicator': { x: 500, y: 580 },
     };


### PR DESCRIPTION
## Changes Made

Added position coordinates for two new chemical solutions in the VirtualLab component:

### New Solution Positions
- **NH4OH 0.1M**: Added at position (540, 200)
- **NH4Cl 0.1M**: Added at position (540, 320)

### Files Modified
- `chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx`

The new positions are added to the existing positions record alongside the current solutions (HCl, acetic acid, and universal indicator).To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 38`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1241ca195be9431cb4572f0a0c3348c4/echo-verse)

👀 [Preview Link](https://1241ca195be9431cb4572f0a0c3348c4-echo-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1241ca195be9431cb4572f0a0c3348c4</projectId>-->
<!--<branchName>echo-verse</branchName>-->