### PR TITLE
Adjust bottle positions in virtual chemistry lab

### DIFF
--- a/chemLab2-main/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
@@ -363,9 +363,9 @@ export default function VirtualLab({
   const getEquipmentPosition = (equipmentId: string) => {
     const positions = {
       'test-tube': { x: 200, y: 250 },           // Left side, center
-      'cobalt-ii-solution': { x: 500, y: 130 },  // Right side, top bottle (moved down for header visibility)
-      'concentrated-hcl': { x: 500, y: 300 },    // Right side, middle bottle
-      'distilled-water': { x: 500, y: 470 }      // Right side, bottom bottle
+      'cobalt-ii-solution': { x: 500, y: 180 },  // Right side, top bottle (moved slightly lower)
+      'concentrated-hcl': { x: 500, y: 350 },    // Right side, middle bottle (moved slightly lower)
+      'distilled-water': { x: 500, y: 520 }      // Right side, bottom bottle (moved slightly lower)
     };
     return positions[equipmentId as keyof typeof positions] || { x: 300, y: 250 };
   };
@@ -1005,7 +1005,7 @@ export default function VirtualLab({
                   <div className="bg-white rounded-lg p-4">
                     <h4 className="font-semibold text-pink-800 mb-2">Adding Water (Stress: ↓ Cl⁻ concentration)</h4>
                     <p className="text-sm text-gray-700">
-                      The system responds by shifting left to counteract the dilution, forming more [Co(H₂O)₆]²⁺ complex (pink color).
+                      The system responds by shifting left to counteract the dilution, forming more [Co(H₂O)₆]²��� complex (pink color).
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Purpose
The user requested to slightly lower the positioning of the cobalt solution, concentrated HCL, and distilled water bottles in the virtual chemistry lab interface to improve the layout and visibility.

## Code changes
- Updated Y-coordinates for three chemical bottles in the equipment positioning system:
  - Cobalt II solution: moved from y: 130 to y: 180 (50px lower)
  - Concentrated HCL: moved from y: 300 to y: 350 (50px lower) 
  - Distilled water: moved from y: 470 to y: 520 (50px lower)
- Updated corresponding comments to reflect the new "slightly lower" positioningTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 47`

🔗 [Edit in Builder.io](https://builder.io/app/projects/69e07a308d5a40efb30b9764ad603509/pixel-nest)

👀 [Preview Link](https://69e07a308d5a40efb30b9764ad603509-pixel-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>69e07a308d5a40efb30b9764ad603509</projectId>-->
<!--<branchName>pixel-nest</branchName>-->