### PR TITLE
Fix pH paper button blinking and results modal timing

### DIFF
--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -463,16 +463,23 @@ const stepsProgress = (
                               setMeasureCount(prev => {
                                 const next = prev + 1;
                                 if (next === 3) {
-                                  // clear any existing timeout
-                                  if (measureTimeoutRef.current) {
-                                    clearTimeout(measureTimeoutRef.current as number);
+                                  // only open results if CASE 2 has been recorded and is eligible to be shown
+                                  if (case2PH != null && case2Version != null && measurementVersion >= case2Version) {
+                                    // clear any existing timeout
+                                    if (measureTimeoutRef.current) {
+                                      clearTimeout(measureTimeoutRef.current as number);
+                                    }
+                                    setShowToast('Opening Results in 5 seconds...');
+                                    measureTimeoutRef.current = window.setTimeout(() => {
+                                      setShowResultsModal(true);
+                                      measureTimeoutRef.current = null;
+                                    }, 5000);
+                                    setTimeout(() => setShowToast(null), 3500);
+                                  } else {
+                                    // Defer opening modal until CASE 2 is available; inform user
+                                    setShowToast('Results not ready yet — complete the sodium additions to generate CASE 2');
+                                    setTimeout(() => setShowToast(null), 2500);
                                   }
-                                  setShowToast('Opening Results in 5 seconds...');
-                                  measureTimeoutRef.current = window.setTimeout(() => {
-                                    setShowResultsModal(true);
-                                    measureTimeoutRef.current = null;
-                                  }, 5000);
-                                  setTimeout(() => setShowToast(null), 3500);
                                 }
                                 return next;
                               });

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -141,7 +141,9 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
         const pos = getPosition(id);
         positionObj = { x: pos.x, y: pos.y, fixed: true };
       } else if (isFixedReagent) {
-        positionObj = { x, y, fixed: true };
+        // always place reagents (ethanoic acid / sodium ethanoate) at their canonical workbench positions
+        const pos = getPosition(id);
+        positionObj = { x: pos.x, y: pos.y, fixed: true };
       } else {
         positionObj = { x, y };
       }

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -457,7 +457,7 @@ const stepsProgress = (
                         return (
                           <Button
                             size="sm"
-                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${paperHasColor ? 'blink-until-pressed' : (!paperHasColor && shouldBlinkMeasure ? 'blink-until-pressed' : '')}`}
+                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${measureCount < 2 && (paperHasColor ? 'blink-until-pressed' : (!paperHasColor && shouldBlinkMeasure ? 'blink-until-pressed' : ''))}` }
                             onClick={() => {
                               // count presses and schedule results modal after 3rd press
                               setMeasureCount(prev => {

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -112,6 +112,10 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
       return { x: baseX, y: baseY + 330 };
     }
     // Stack the two reagent cards in a right column similar to the screenshot
+    // Ensure sodium ethanoate is slightly lower than ethanoic acid to provide a small gap
+    if (id.toLowerCase().includes('sodium')) {
+      return { x: baseX + 260, y: baseY + 280 };
+    }
     return { x: baseX + 260, y: baseY + (idx === 1 ? 40 : 220) };
   };
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UX issues in the ethanoic acid buffer experiment:
- Stop the "new pH paper" button from blinking after it's been pressed twice
- Prevent the results page from opening until Case 2 (sodium ethanoate addition) results are calculated
- Ensure reagent bottles are positioned at specific workbench locations with proper spacing between them

## Code changes

- **Button blinking fix**: Added condition `measureCount < 2` to stop blinking the pH paper button after 2 presses
- **Results modal timing**: Added validation to check if `case2PH` and `case2Version` are available before opening results modal on 3rd press
- **Reagent positioning**: 
  - Modified `getPosition()` to place sodium ethanoate slightly lower (y: 280) than ethanoic acid for visual gap
  - Updated reagent positioning logic to always use canonical workbench positions regardless of drop location
- **User feedback**: Added toast message when results aren't ready yet, informing users to complete sodium additions firstTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 51`

🔗 [Edit in Builder.io](https://builder.io/app/projects/69e07a308d5a40efb30b9764ad603509/spark-haven)

👀 [Preview Link](https://69e07a308d5a40efb30b9764ad603509-spark-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>69e07a308d5a40efb30b9764ad603509</projectId>-->
<!--<branchName>spark-haven</branchName>-->