### PR TITLE
Add blinking effects for measure and new pH paper buttons

### DIFF
--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -61,6 +61,8 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
   const [measureCount, setMeasureCount] = useState(0);
   // Track whether the MEASURE action has been pressed (used to stop blinking prompts)
   const [measurePressed, setMeasurePressed] = useState(false);
+  // Track whether the 'New pH paper' action has been pressed
+  const [newPaperPressed, setNewPaperPressed] = useState(false);
   const measureTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -72,7 +74,7 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
     };
   }, []);
 
-  useEffect(() => { setEquipmentOnBench([]); setAcidMoles(0); setSodiumMoles(0); setLastMeasuredPH(null); setInitialAcidPH(null); setCase1PH(null); setCase2PH(null); setShowToast(null); setMeasurePressed(false); }, [experiment.id]);
+  useEffect(() => { setEquipmentOnBench([]); setAcidMoles(0); setSodiumMoles(0); setLastMeasuredPH(null); setInitialAcidPH(null); setCase1PH(null); setCase2PH(null); setShowToast(null); setMeasurePressed(false); setNewPaperPressed(false); }, [experiment.id]);
 
   const items = useMemo(() => {
     const iconFor = (name: string) => {
@@ -465,8 +467,8 @@ const stepsProgress = (
                         return (
                           <Button
                             size="sm"
-                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${!measurePressed ? 'blink-until-pressed' : ''}` }
-                            onClick={() => { setMeasurePressed(true);
+                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${(!paperHasColor ? !measurePressed : !newPaperPressed) ? 'blink-until-pressed' : ''}` }
+                            onClick={() => { if (!paperHasColor) { setMeasurePressed(true); } else { setNewPaperPressed(true); }
                               // count presses and schedule results modal after 3rd press
                               setMeasureCount(prev => {
                                 const next = prev + 1;

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -236,6 +236,9 @@ const confirmAddSodium = () => {
   if (nextAdditions >= 2) setShouldBlinkReset(false);
   // prompt user to measure after adding sodium ethanoate (only if fewer than 3 total measurements so far)
   setShouldBlinkMeasure(measurementVersion < 3);
+  // Re-enable the blinking prompt for MEASURE after adding sodium
+  setMeasurePressed(false);
+  setNewPaperPressed(false);
 
   // compute and store pH after sodium ethanoate addition
   const totalVolL = Math.max(1e-6, newTestTubeVolume / 1000);
@@ -467,7 +470,7 @@ const stepsProgress = (
                         return (
                           <Button
                             size="sm"
-                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${(!paperHasColor ? !measurePressed : !newPaperPressed) ? 'blink-until-pressed' : ''}` }
+                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${(shouldBlinkMeasure || (!paperHasColor ? !measurePressed : !newPaperPressed)) ? 'blink-until-pressed' : ''}` }
                             onClick={() => { if (!paperHasColor) { setMeasurePressed(true); } else { setNewPaperPressed(true); }
                               // count presses and schedule results modal after 3rd press
                               setMeasureCount(prev => {

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -348,6 +348,8 @@ useEffect(() => {
   // If CASE 2 has been recorded, stop any blinking prompt immediately
   if (case2PH != null) {
     setShouldBlinkMeasure(false);
+    // stop blinking "New pH paper" as results are now calculated
+    setNewPaperPressed(true);
   }
 
   if (case2PH != null && case2Version != null && measurementVersion >= case2Version) {

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -465,7 +465,7 @@ const stepsProgress = (
                         return (
                           <Button
                             size="sm"
-                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${!measurePressed && measureCount < 2 && (paperHasColor ? 'blink-until-pressed' : (!paperHasColor && shouldBlinkMeasure ? 'blink-until-pressed' : ''))}` }
+                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${!measurePressed ? 'blink-until-pressed' : ''}` }
                             onClick={() => { setMeasurePressed(true);
                               // count presses and schedule results modal after 3rd press
                               setMeasureCount(prev => {
@@ -720,7 +720,7 @@ const stepsProgress = (
             <div>
               <h4 className="font-semibold mb-2">Action Timeline</h4>
               <ol className="list-decimal list-inside text-sm text-gray-700">
-                <li>Added ethanoic acid — initial pH recorded {initialAcidPH != null ? `(${initialAcidPH.toFixed(2)})` : ''}</li>
+                <li>Added ethanoic acid �� initial pH recorded {initialAcidPH != null ? `(${initialAcidPH.toFixed(2)})` : ''}</li>
                 <li>Added sodium ethanoate ��� stored CASE values {case1PH != null ? `CASE1: ${case1PH.toFixed(2)}` : ''} {case2PH != null ? `CASE2: ${case2PH.toFixed(2)}` : ''}</li>
               </ol>
             </div>

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -59,6 +59,8 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
 
   // Count measure button presses and schedule showing results after 3rd press
   const [measureCount, setMeasureCount] = useState(0);
+  // Track whether the MEASURE action has been pressed (used to stop blinking prompts)
+  const [measurePressed, setMeasurePressed] = useState(false);
   const measureTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -70,7 +72,7 @@ export default function VirtualLab({ experiment, experimentStarted, onStartExper
     };
   }, []);
 
-  useEffect(() => { setEquipmentOnBench([]); setAcidMoles(0); setSodiumMoles(0); setLastMeasuredPH(null); setInitialAcidPH(null); setCase1PH(null); setCase2PH(null); setShowToast(null); }, [experiment.id]);
+  useEffect(() => { setEquipmentOnBench([]); setAcidMoles(0); setSodiumMoles(0); setLastMeasuredPH(null); setInitialAcidPH(null); setCase1PH(null); setCase2PH(null); setShowToast(null); setMeasurePressed(false); }, [experiment.id]);
 
   const items = useMemo(() => {
     const iconFor = (name: string) => {
@@ -463,8 +465,8 @@ const stepsProgress = (
                         return (
                           <Button
                             size="sm"
-                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${measureCount < 2 && (paperHasColor ? 'blink-until-pressed' : (!paperHasColor && shouldBlinkMeasure ? 'blink-until-pressed' : ''))}` }
-                            onClick={() => {
+                            className={`measure-action-btn bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${!measurePressed && measureCount < 2 && (paperHasColor ? 'blink-until-pressed' : (!paperHasColor && shouldBlinkMeasure ? 'blink-until-pressed' : ''))}` }
+                            onClick={() => { setMeasurePressed(true);
                               // count presses and schedule results modal after 3rd press
                               setMeasureCount(prev => {
                                 const next = prev + 1;


### PR DESCRIPTION
## Purpose
The user wanted to improve the user experience by adding visual cues to guide users through the experiment workflow. Specifically, they requested blinking effects on the "measure" and "new pH paper" buttons to prompt users when these actions should be taken, with the blinking stopping once the buttons are pressed or when certain conditions are met (like when case 2 results are calculated).

## Code changes
- Added two new state variables `measurePressed` and `newPaperPressed` to track button press status
- Modified the button className logic to implement conditional blinking based on paper state and press status
- Updated the onClick handler to set the appropriate pressed state when buttons are clicked
- Added logic to stop blinking the "new pH paper" button when case 2 results are calculated
- Reset both pressed states when sodium ethanoate is added to re-enable blinking prompts
- Reset states when experiment changes to ensure clean state for new experimentsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 52`

🔗 [Edit in Builder.io](https://builder.io/app/projects/69e07a308d5a40efb30b9764ad603509/stellar-den)

👀 [Preview Link](https://69e07a308d5a40efb30b9764ad603509-stellar-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>69e07a308d5a40efb30b9764ad603509</projectId>-->
<!--<branchName>stellar-den</branchName>-->