### PR TITLE
Add View Results button and reduce auto-open delay to 5s

### DIFF
--- a/chemLab2-main/client/src/components/BufferWorkbenchMock.tsx
+++ b/chemLab2-main/client/src/components/BufferWorkbenchMock.tsx
@@ -40,6 +40,7 @@ export default function BufferWorkbenchMock() {
 
                   <div className="space-y-2">
                     <Button variant="outline" className="w-full bg-white border-gray-200 text-gray-700 hover:bg-gray-100 flex items-center justify-center"><Undo2 className="w-4 h-4 mr-2" />UNDO</Button>
+                    <Button className="w-full bg-white border-gray-200 text-gray-700 hover:bg-gray-100 flex items-center justify-center"><CheckCircle className="w-4 h-4 mr-2 text-green-600" />View Results & Analysis</Button>
                     <Button variant="destructive" className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100">Reset Experiment</Button>
                   </div>
                 </aside>

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/VirtualLab.tsx
@@ -353,13 +353,13 @@ useEffect(() => {
   }
 
   if (case2PH != null && case2Version != null && measurementVersion >= case2Version) {
-    setShowToast('Opening Results in 10 seconds...');
+    setShowToast('Opening Results in 5 seconds...');
     case2TimeoutRef.current = window.setTimeout(() => {
       setShowResultsModal(true);
       case2TimeoutRef.current = null;
-    }, 10000);
+    }, 5000);
     // clear the toast a bit earlier than the modal
-    setTimeout(() => setShowToast(null), 8000);
+    setTimeout(() => setShowToast(null), 4000);
   }
 
   return () => {


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses two key improvements to the ethanoic acid buffer experiment interface:
1. **Enhanced user control**: Users requested a dedicated "View Results & Analysis" button to manually access experiment results
2. **Improved timing**: Users wanted faster access to results, requesting the auto-open delay be reduced from 10 seconds to 5 seconds for case 2 results

## Code Changes
- **Added "View Results & Analysis" button** in `BufferWorkbenchMock.tsx` positioned between the UNDO and Reset Experiment buttons with CheckCircle icon and consistent styling
- **Reduced auto-open timing** in `VirtualLab.tsx` for case 2 results from 10 seconds to 5 seconds, with corresponding toast message and timeout adjustmentsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 53`

🔗 [Edit in Builder.io](https://builder.io/app/projects/69e07a308d5a40efb30b9764ad603509/spark-haven)

👀 [Preview Link](https://69e07a308d5a40efb30b9764ad603509-spark-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>69e07a308d5a40efb30b9764ad603509</projectId>-->
<!--<branchName>spark-haven</branchName>-->