### PR TITLE
Update image URL for ethanoic acid pH experiment

### DIFF
--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/BufferPHApp.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/BufferPHApp.tsx
@@ -82,6 +82,11 @@ export default function BufferPHApp({ onBack }: Props) {
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">{experiment.title}</h1>
           <p className="text-gray-600 mb-4">{experiment.description}</p>
+          {experiment.imageUrl ? (
+            <div className="mb-4">
+              <img src={experiment.imageUrl} alt={experiment.title} className="w-full h-48 md:h-56 object-cover rounded" loading="lazy" />
+            </div>
+          ) : null}
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center space-x-4">
               <span className="px-3 py-1 rounded-full bg-blue-100 text-blue-700 text-sm font-medium">Guided Mode</span>

--- a/chemLab2-main/client/src/experiments/EthanoicBuffer/components/BufferPHApp.tsx
+++ b/chemLab2-main/client/src/experiments/EthanoicBuffer/components/BufferPHApp.tsx
@@ -82,11 +82,6 @@ export default function BufferPHApp({ onBack }: Props) {
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">{experiment.title}</h1>
           <p className="text-gray-600 mb-4">{experiment.description}</p>
-          {experiment.imageUrl ? (
-            <div className="mb-4">
-              <img src={experiment.imageUrl} alt={experiment.title} className="w-full h-48 md:h-56 object-cover rounded" loading="lazy" />
-            </div>
-          ) : null}
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center space-x-4">
               <span className="px-3 py-1 rounded-full bg-blue-100 text-blue-700 text-sm font-medium">Guided Mode</span>

--- a/chemLab2-main/data/experiments.json
+++ b/chemLab2-main/data/experiments.json
@@ -580,7 +580,7 @@
     "duration": 30,
     "steps": 6,
     "rating": 4.6,
-    "imageUrl": "https://images.unsplash.com/photo-1581091012184-7a5f4b1b2f6a?auto=format&fit=crop&w=800&q=80",
+    "imageUrl": "https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2F1db7dcc49eb14d588e9dbadced019952?format=webp&width=800",
     "equipment": [
       "Beakers",
       "Test Tubes",


### PR DESCRIPTION
## Purpose
The user requested to add a specific image for the ethanoic acid pH experiment (studying pH changes when adding sodium ethanoate) and specified that the image should not be displayed on the workbench.

## Code changes
- Updated the `imageUrl` field in the experiments.json file for the ethanoic acid pH experiment
- Replaced the Unsplash image URL with a Builder.io CDN image URL
- The new image is specifically related to the experiment's purpose of studying pH changes in ethanoic acid with sodium ethanoate additionTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 54`

🔗 [Edit in Builder.io](https://builder.io/app/projects/69e07a308d5a40efb30b9764ad603509/zen-field)

👀 [Preview Link](https://69e07a308d5a40efb30b9764ad603509-zen-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>69e07a308d5a40efb30b9764ad603509</projectId>-->
<!--<branchName>zen-field</branchName>-->