### PR TITLE
Replace universal indicator with pH paper in ammonium buffer experiment

### DIFF
--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/Equipment.tsx
@@ -6,5 +6,5 @@ export const AB_LAB_EQUIPMENT = [
   { id: 'test-tube', name: '25ml Test Tube', icon: <TestTube className="w-8 h-8" /> },
   { id: 'nh4oh-0-1m', name: '0.1 M Ammonium Hydroxide', icon: <Droplets className="w-8 h-8" /> },
   { id: 'nh4cl-0-1m', name: '0.1 M Ammonium Chloride', icon: <Droplets className="w-8 h-8" /> },
-  { id: 'universal-indicator', name: 'Universal Indicator', icon: <FlaskConical className="w-8 h-8" /> },
+  { id: 'ph-paper', name: 'pH Paper', icon: <FlaskConical className="w-8 h-8" /> },
 ];

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -333,7 +333,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                   {/* Show RESET button below the test tube when universal indicator has been added */}
                   {testTube.contents.includes('IND') && (
                     <div style={{ position: 'absolute', left: getEquipmentPosition('test-tube').x, top: getEquipmentPosition('test-tube').y + 220, transform: 'translate(-50%, 0)' }}>
-                      <Button size="sm" className="bg-blue-500 hover:bg-blue-600 text-white shadow-sm animate-pulse" onClick={() => {
+                      <Button size="sm" className="hidden" onClick={() => {
                         // Restore test tube to empty/clear state
                         setHistory([]);
                         setTestTube(prev => ({ ...prev, volume: 0, contents: [], colorHex: COLORS.CLEAR }));

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -373,6 +373,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                   position={e.position}
                   onRemove={handleRemove}
                   onInteract={handleInteract}
+                  color={(e as any).color}
                 />
               ))}
 

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -233,7 +233,6 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
     if (id === 'nh4oh-0-1m') setShowNh4ohDialog(true);
     if (id === 'nh4cl-0-1m') setShowNh4clDialog(true);
     if (id === 'ph-paper') { addToTube('IND', 0); if (currentStep === 3 || currentStep === 5) onStepComplete(currentStep); return; }
-    if (id === 'universal-indicator') { setShowIndicatorDialog(true); return; }
   };
 
   const handleRemove = (id: string) => { setEquipmentOnBench(prev => prev.filter(e => e.id !== id)); if (id === 'test-tube') setTestTube(INITIAL_TESTTUBE); };

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -127,8 +127,8 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
           else nextColor = COLORS.NEUTRAL;
           animateColorTransition(nextColor);
         } else if (newVol > 0) {
-          // Show a light-blue liquid when volume is added but no pH paper is present
-          nextColor = '#ADD8E6';
+          // Show base blue liquid when volume is added but no pH paper is present (matches reference)
+          nextColor = COLORS.NH4OH_BASE;
         }
         const label = reagent === 'NH4OH' ? 'Added NH4OH' : reagent === 'NH4Cl' ? 'Added NH4Cl' : 'Added pH paper';
         const observation = contents.includes('IND')

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -63,7 +63,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
   const getEquipmentPosition = (equipmentId: string) => {
     const baseTestTube = { x: 200, y: 250 };
     const tubeOnBench = equipmentOnBench.find(e => e.id === 'test-tube');
-    const commonBottleIds = ['nh4oh-0-1m', 'nh4cl-0-1m', 'universal-indicator'];
+    const commonBottleIds = ['nh4oh-0-1m', 'nh4cl-0-1m', 'ph-paper'];
     if (commonBottleIds.includes(equipmentId)) {
       const baseX = tubeOnBench ? tubeOnBench.position.x + 260 : 580;
       const baseY = tubeOnBench ? tubeOnBench.position.y - 80 : 200;
@@ -232,6 +232,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
   const handleInteract = (id: string) => {
     if (id === 'nh4oh-0-1m') setShowNh4ohDialog(true);
     if (id === 'nh4cl-0-1m') setShowNh4clDialog(true);
+    if (id === 'ph-paper') { addToTube('IND', 0); if (currentStep === 3 || currentStep === 5) onStepComplete(currentStep); return; }
     if (id === 'universal-indicator') { setShowIndicatorDialog(true); return; }
   };
 

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -400,16 +400,13 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
           <div className="lg:col-span-3 space-y-4">
             <div className="bg-white/90 backdrop-blur-sm rounded-xl p-4 border border-gray-200 shadow-sm">
               <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-                <Info className="w-5 h-5 mr-2 text-green-600" />
+                <span className="inline-block w-2.5 h-2.5 rounded-full bg-green-500 mr-2" aria-hidden="true" />
                 Live Analysis
               </h3>
+
               <div className="mb-4">
-                <h4 className="font-semibold text-sm text-gray-700 mb-2">Current Solution</h4>
-                <div className="flex items-center space-x-2 mb-2">
-                  <div className="w-4 h-4 rounded-full border border-gray-300" style={{ backgroundColor: testTube.colorHex }}></div>
-                  <span className="text-sm">{testTube.contents.includes('IND') ? 'With pH paper' : (testTube.colorHex === COLORS.CLEAR ? 'Clear (no indicator)' : 'With indicator')}</span>
-                </div>
-                <p className="text-xs text-gray-600">Contents: {testTube.contents.join(', ') || 'None'}</p>
+                <h4 className="font-semibold text-sm text-gray-700 mb-2">Current Step</h4>
+                <p className="text-xs text-gray-600">{GUIDED_STEPS[(mode.currentGuidedStep || 0)]?.title || GUIDED_STEPS[currentStep-1]?.title}</p>
               </div>
 
               <div className="mb-4">
@@ -437,12 +434,27 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                     );
                   })()}
                 </div>
+
+                <div className="mt-6">
+                  <h5 className="font-medium text-sm text-black mb-1"><span className="inline-block w-2 h-2 rounded-full bg-black mr-2" aria-hidden="true" /> <span className="inline-block mr-2 font-bold">A</span> pH of Ammonium hydroxide</h5>
+                  <div className="text-lg text-black font-semibold">{baseSample != null ? `${baseSample.volume.toFixed(1)} mL • pH ≈ ${lastMeasuredPH != null ? lastMeasuredPH.toFixed(2) : '—'}` : 'No result yet'}</div>
+                </div>
+
+                <div className="text-sm text-black mt-3 mb-2"><span className="inline-block w-2 h-2 rounded-full bg-black mr-2" aria-hidden="true" /> <span className="inline-block mr-2 font-bold">B</span> When NH4Cl is added</div>
+                <div className="mt-3 grid grid-cols-1 gap-2">
+                  <div className="p-2 rounded border border-gray-200 bg-gray-50 text-sm">
+                    <div className="font-medium">CASE 1</div>
+                    <div className="text-lg text-black font-semibold">{bufferedSample != null ? `${bufferedSample.volume.toFixed(1)} mL • pH ≈ ${lastMeasuredPH != null ? lastMeasuredPH.toFixed(2) : '—'}` : 'No result yet'}</div>
+                  </div>
+                  <div className="p-2 rounded border border-gray-200 bg-gray-50 text-sm">
+                    <div className="font-medium">CASE 2</div>
+                    <div className="text-lg text-black font-semibold">No result yet</div>
+                  </div>
+                </div>
+
+                {showToast && <p className="text-xs text-blue-700 mt-2">{showToast}</p>}
               </div>
             </div>
-
-            {showToast && (
-              <div className="p-3 rounded bg-blue-50 border border-blue-200 text-blue-700 text-sm">{showToast}</div>
-            )}
           </div>
         </div>
       </div>

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -252,11 +252,13 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
 
   const testPH = () => {
     if (!testTube || (testTube.volume ?? 0) <= 0) { setShowToast('No solution in test tube'); setTimeout(() => setShowToast(''), 1400); return; }
-    if (!testTube.contents.includes('IND')) { setShowToast('No indicator present. Add universal indicator or pH paper'); setTimeout(() => setShowToast(''), 1800); return; }
+    if (!testTube.contents.includes('IND')) { setShowToast('No indicator present. Add pH paper'); setTimeout(() => setShowToast(''), 1800); return; }
 
     if (testTube.contents.includes('NH4Cl')) {
       const ph = 9.0;
       setLastMeasuredPH(ph);
+      // color pH paper to buffered color
+      setEquipmentOnBench(prev => prev.map(item => (item.id === 'ph-paper' || item.id.toLowerCase().includes('ph')) ? { ...item, color: COLORS.NH4_BUFFERED } : item));
       setShowToast('Measured pH ≈ 9 (buffered, lower than NH4OH)');
       setTimeout(() => setShowToast(''), 2000);
       return;
@@ -264,6 +266,8 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
     if (testTube.contents.includes('NH4OH')) {
       const ph = 11.0;
       setLastMeasuredPH(ph);
+      // color pH paper to basic color
+      setEquipmentOnBench(prev => prev.map(item => (item.id === 'ph-paper' || item.id.toLowerCase().includes('ph')) ? { ...item, color: COLORS.NH4OH_BASE } : item));
       setShowToast('Measured pH ≈ 11 (basic NH4OH)');
       setTimeout(() => setShowToast(''), 2000);
       return;
@@ -271,11 +275,14 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
     if (testTube.colorHex === COLORS.NEUTRAL) {
       const ph = 7.0;
       setLastMeasuredPH(ph);
+      setEquipmentOnBench(prev => prev.map(item => (item.id === 'ph-paper' || item.id.toLowerCase().includes('ph')) ? { ...item, color: COLORS.NEUTRAL } : item));
       setShowToast('Measured pH ≈ 7 (neutral)');
       setTimeout(() => setShowToast(''), 2000);
       return;
     }
     setLastMeasuredPH(null);
+    // set pH paper to clear/inconclusive
+    setEquipmentOnBench(prev => prev.map(item => (item.id === 'ph-paper' || item.id.toLowerCase().includes('ph')) ? { ...item, color: COLORS.CLEAR } : item));
     setShowToast('pH measurement inconclusive');
     setTimeout(() => setShowToast(''), 1600);
   };

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -126,6 +126,9 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
           else if (contents.includes('NH4OH')) nextColor = COLORS.NH4OH_BASE; // basic
           else nextColor = COLORS.NEUTRAL;
           animateColorTransition(nextColor);
+        } else if (newVol > 0) {
+          // Show a light-blue liquid when volume is added but no pH paper is present
+          nextColor = '#ADD8E6';
         }
         const label = reagent === 'NH4OH' ? 'Added NH4OH' : reagent === 'NH4Cl' ? 'Added NH4Cl' : 'Added pH paper';
         const observation = contents.includes('IND')

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -65,8 +65,21 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
     const tubeOnBench = equipmentOnBench.find(e => e.id === 'test-tube');
     const commonBottleIds = ['nh4oh-0-1m', 'nh4cl-0-1m', 'ph-paper'];
     if (commonBottleIds.includes(equipmentId)) {
-      const baseX = tubeOnBench ? tubeOnBench.position.x + 260 : 580;
-      const baseY = tubeOnBench ? tubeOnBench.position.y - 80 : 200;
+      // Place pH paper directly below the test tube when tube is present
+      if (tubeOnBench) {
+        if (equipmentId === 'ph-paper') {
+          return { x: tubeOnBench.position.x, y: tubeOnBench.position.y + 160 };
+        }
+        const baseX = tubeOnBench.position.x + 260;
+        const baseY = tubeOnBench.position.y - 80;
+        const spacing = 160;
+        const index = commonBottleIds.indexOf(equipmentId);
+        return { x: baseX, y: baseY + index * spacing };
+      }
+      // Fallback positions when no tube: place pH paper below center
+      if (equipmentId === 'ph-paper') return { x: 300, y: 420 };
+      const baseX = 580;
+      const baseY = 200;
       const spacing = 160;
       const index = commonBottleIds.indexOf(equipmentId);
       return { x: baseX, y: baseY + index * spacing };

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -371,6 +371,18 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                   onInteract={handleInteract}
                 />
               ))}
+
+              {/* Contextual MEASURE action near pH paper when present */}
+              {equipmentOnBench.find(e => e.id === 'ph-paper' || e.id.toLowerCase().includes('ph')) && (
+                (() => {
+                  const phItem = equipmentOnBench.find(e => e.id === 'ph-paper' || e.id.toLowerCase().includes('ph'))!;
+                  return (
+                    <div key="measure-button" style={{ position: 'absolute', left: phItem.position.x + 90, top: phItem.position.y, transform: 'translate(-50%, -50%)' }}>
+                      <Button size="sm" className={`bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${!measurePressed ? 'blink-until-pressed' : ''}`} onClick={() => { setMeasurePressed(true); testPH(); }}>MEASURE</Button>
+                    </div>
+                  );
+                })()
+              )}
             </WorkBench>
           </div>
 

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -377,7 +377,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                 (() => {
                   const phItem = equipmentOnBench.find(e => e.id === 'ph-paper' || e.id.toLowerCase().includes('ph'))!;
                   return (
-                    <div key="measure-button" style={{ position: 'absolute', left: phItem.position.x + 90, top: phItem.position.y, transform: 'translate(-50%, -50%)' }}>
+                    <div key="measure-button" style={{ position: 'absolute', left: phItem.position.x, top: phItem.position.y + 60, transform: 'translate(-50%, 0)' }}>
                       <Button size="sm" className={`bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${!measurePressed ? 'blink-until-pressed' : ''}`} onClick={() => { setMeasurePressed(true); testPH(); }}>MEASURE</Button>
                     </div>
                   );

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -173,6 +173,12 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
       return prev;
     });
 
+    // if pH paper placed, also add it logically to the test tube (contents) so measurement works immediately
+    if (equipmentId === 'ph-paper') {
+      addToTube('IND', 0);
+      if (currentStep === 3 || currentStep === 5) onStepComplete(currentStep);
+    }
+
     // mark step complete only for interactive (non-fixed) placements
     if (!['nh4oh-0-1m','nh4cl-0-1m','ph-paper'].includes(equipmentId)) {
       if (!completedSteps.includes(currentStep)) onStepComplete(currentStep);

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -407,7 +407,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                 <h4 className="font-semibold text-sm text-gray-700 mb-2">Current Solution</h4>
                 <div className="flex items-center space-x-2 mb-2">
                   <div className="w-4 h-4 rounded-full border border-gray-300" style={{ backgroundColor: testTube.colorHex }}></div>
-                  <span className="text-sm">{testTube.colorHex === COLORS.CLEAR ? 'Clear (no indicator)' : 'With indicator'}</span>
+                  <span className="text-sm">{testTube.contents.includes('IND') ? 'With pH paper' : (testTube.colorHex === COLORS.CLEAR ? 'Clear (no indicator)' : 'With indicator')}</span>
                 </div>
                 <p className="text-xs text-gray-600">Contents: {testTube.contents.join(', ') || 'None'}</p>
               </div>

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/constants.ts
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/constants.ts
@@ -17,7 +17,7 @@ export const INITIAL_TESTTUBE = {
 export const GUIDED_STEPS = [
   { id: 1, title: 'Place Test Tube', description: 'Drag the test tube to the workbench.', action: 'Place test tube', equipment: ['test-tube'], completed: false },
   { id: 2, title: 'Add 0.1 M NH4OH', description: 'Drag the ammonium hydroxide bottle to the workbench and add NH4OH to the test tube.', action: 'Add NH4OH', equipment: ['test-tube', 'nh4oh-0-1m'], completed: false },
-  { id: 3, title: 'Add Universal Indicator', description: 'Add universal indicator to observe the basic color (blue/green).', action: 'Add indicator', equipment: ['test-tube', 'universal-indicator'], completed: false },
+  { id: 3, title: 'Add pH Paper', description: 'Place pH paper on the workbench and use it to observe the pH change (no volume required).', action: 'Add pH paper', equipment: ['test-tube', 'ph-paper'], completed: false },
   { id: 4, title: 'Add NH4Cl (Common Ion)', description: 'Add ammonium chloride to shift equilibrium (common-ion effect).', action: 'Add NH4Cl', equipment: ['test-tube', 'nh4cl-0-1m'], completed: false },
   { id: 5, title: 'Measure and Observe pH', description: 'Measure pH after addition of NH4Cl. The pH should decrease compared to pure NH4OH.', action: 'Measure pH', equipment: ['test-tube'], completed: false },
   { id: 6, title: 'Compare and Conclude', description: 'Compare colors/measurements and conclude the effect of NH4+ on NH3/NH4+ equilibrium.', action: 'Compare', equipment: ['test-tube'], completed: false },

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/data.ts
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/data.ts
@@ -1,7 +1,7 @@
 const AmmoniumBufferData = {
   id: 9,
   title: "To study the change in pH of ammonium hydroxide solution on addition of ammonium chloride",
-  description: "Investigate how adding ammonium chloride (NH4Cl) to an ammonium hydroxide (NH4OH) solution affects pH via the common‑ion effect. Observe the color change with universal indicator and the drop in pH.",
+  description: "Investigate how adding ammonium chloride (NH4Cl) to an ammonium hydroxide (NH4OH) solution affects pH via the common‑ion effect. Observe the color change using pH paper and note the drop in pH.",
   category: "Acid-Base Chemistry",
   difficulty: "Beginner",
   duration: 20,

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/data.ts
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/data.ts
@@ -12,7 +12,7 @@ const AmmoniumBufferData = {
     "25ml Test Tube",
     "0.1 M NH4OH",
     "0.1 M NH4Cl",
-    "Universal Indicator",
+    "pH Paper",
     "Dropper",
     "pH Color Chart",
     "Distilled Water"
@@ -20,7 +20,7 @@ const AmmoniumBufferData = {
   stepDetails: [
     { id: 1, title: "Setup Workbench", description: "Drag the test tube onto the workbench.", duration: "2 minutes", completed: false },
     { id: 2, title: "Add 0.1 M NH4OH", description: "Add NH4OH to the test tube.", duration: "3 minutes", completed: false },
-    { id: 3, title: "Add Universal Indicator", description: "Add 2–3 drops of universal indicator (expect blue/green → basic).", duration: "3 minutes", completed: false },
+    { id: 3, title: "Add pH Paper", description: "Place pH paper in contact with the solution to observe the pH color (no drops required).", duration: "3 minutes", completed: false },
     { id: 4, title: "Add NH4Cl (Common Ion)", description: "Add NH4Cl to the same test tube (pH decreases due to common‑ion effect).", duration: "3 minutes", completed: false },
     { id: 5, title: "Measure pH", description: "Measure pH or compare color with the chart (expect lower than Step 3).", duration: "3 minutes", completed: false },
     { id: 6, title: "Compare and Conclude", description: "Explain why adding NH4+ lowers the pH of NH4OH.", duration: "6 minutes", completed: false }


### PR DESCRIPTION
## Purpose

The user requested to modify the ammonium buffer experiment workbench to use pH paper instead of universal indicator for measuring pH changes. They wanted the pH paper to change color when the "MEASURE" button is pressed, and requested the test tube liquid to display a light blue color when volume is added, matching a reference image they provided.

## Code changes

- **Equipment update**: Replaced "Universal Indicator" with "pH Paper" in equipment list
- **UI positioning**: Implemented fixed positioning system for reagent bottles and pH paper on the workbench
- **pH paper functionality**: Added automatic pH paper placement and color change logic when MEASURE button is pressed
- **Visual feedback**: Updated test tube to show light blue color (NH4OH base color) when volume is added
- **Measurement system**: Modified pH testing to work with pH paper instead of universal indicator, with visual color changes on the paper
- **Step descriptions**: Updated guided steps and experiment description to reference pH paper instead of universal indicator
- **Live analysis**: Enhanced the results display section with structured pH measurement results for both base solution and buffered casesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 58`

🔗 [Edit in Builder.io](https://builder.io/app/projects/69e07a308d5a40efb30b9764ad603509/orbit-studio)

👀 [Preview Link](https://69e07a308d5a40efb30b9764ad603509-orbit-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>69e07a308d5a40efb30b9764ad603509</projectId>-->
<!--<branchName>orbit-studio</branchName>-->