### PR TITLE
Add blinking effects for MEASURE and New pH paper buttons

### DIFF
--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -198,6 +198,9 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
     // if pH paper placed, also add it logically to the test tube (contents) so measurement works immediately
     if (equipmentId === 'ph-paper') {
       addToTube('IND', 0);
+      // reset measurement prompts when new pH paper is placed
+      setMeasurePressed(false);
+      setNewPaperPressed(false);
       if (currentStep === 3 || currentStep === 5) onStepComplete(currentStep);
     }
 
@@ -422,7 +425,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                   const paperHasColor = !!(phItem as any).color && (phItem as any).color !== COLORS.CLEAR;
                   return (
                     <div key="measure-button" style={{ position: 'absolute', left: phItem.position.x, top: phItem.position.y + 60, transform: 'translate(-50%, 0)' }}>
-                      <Button size="sm" className={`bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${(!paperHasColor && lastMeasuredPH == null) ? 'blink-until-pressed' : ''}`} onClick={() => { if (!paperHasColor) { setMeasurePressed(true); testPH(); } else { setNewPaperPressed(true); setEquipmentOnBench(prev => prev.map(item => (item.id === 'ph-paper' || item.id.toLowerCase().includes('ph')) ? { ...item, color: COLORS.CLEAR } : item)); setShowToast('Replace pH paper'); setTimeout(() => setShowToast(''), 1500); } }}>
+                      <Button size="sm" className={`bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${(!paperHasColor && !measurePressed) ? 'blink-until-pressed' : ''}`} onClick={() => { if (!paperHasColor) { setMeasurePressed(true); testPH(); } else { setNewPaperPressed(true); setMeasurePressed(false); setEquipmentOnBench(prev => prev.map(item => (item.id === 'ph-paper' || item.id.toLowerCase().includes('ph')) ? { ...item, color: COLORS.CLEAR } : item)); setShowToast('Replace pH paper'); setTimeout(() => setShowToast(''), 1500); } }}>
                         {!paperHasColor ? 'MEASURE' : 'New pH paper'}
                       </Button>
                     </div>

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -425,7 +425,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                   const paperHasColor = !!(phItem as any).color && (phItem as any).color !== COLORS.CLEAR;
                   return (
                     <div key="measure-button" style={{ position: 'absolute', left: phItem.position.x, top: phItem.position.y + 60, transform: 'translate(-50%, 0)' }}>
-                      <Button size="sm" className={`bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${(!paperHasColor && !measurePressed) ? 'blink-until-pressed' : ''}`} onClick={() => { if (!paperHasColor) { setMeasurePressed(true); testPH(); } else { setNewPaperPressed(true); setMeasurePressed(false); setEquipmentOnBench(prev => prev.map(item => (item.id === 'ph-paper' || item.id.toLowerCase().includes('ph')) ? { ...item, color: COLORS.CLEAR } : item)); setShowToast('Replace pH paper'); setTimeout(() => setShowToast(''), 1500); } }}>
+                      <Button size="sm" className={`bg-amber-600 text-white hover:bg-amber-700 shadow-sm ${((!paperHasColor && !measurePressed) || (paperHasColor && !newPaperPressed)) ? 'blink-until-pressed' : ''}`} onClick={() => { if (!paperHasColor) { setMeasurePressed(true); testPH(); } else { setNewPaperPressed(true); setMeasurePressed(false); setEquipmentOnBench(prev => prev.map(item => (item.id === 'ph-paper' || item.id.toLowerCase().includes('ph')) ? { ...item, color: COLORS.CLEAR } : item)); setShowToast('Replace pH paper'); setTimeout(() => setShowToast(''), 1500); } }}>
                         {!paperHasColor ? 'MEASURE' : 'New pH paper'}
                       </Button>
                     </div>


### PR DESCRIPTION
## Purpose
The user requested visual feedback to guide users through the ammonium buffer pH experiment by adding blinking effects to critical action buttons. This helps users understand when they need to press the "MEASURE" button to test pH and when they need to press the "New pH paper" button to replace used pH paper.

## Code changes
- **Enhanced button blinking logic**: Updated the className condition to properly handle blinking for both button states - "MEASURE" button blinks until pressed when paper has no color, and "New pH paper" button blinks until pressed when paper has color
- **Added state reset mechanism**: When new pH paper is placed, both `measurePressed` and `newPaperPressed` states are reset to `false` to ensure proper blinking behavior for subsequent measurements
- **Improved button click handler**: Added `setMeasurePressed(false)` when "New pH paper" is clicked to reset the measure state for the next measurement cycle

These changes ensure users receive clear visual cues about which actions to take during the pH measurement process in the virtual chemistry lab.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 62`

🔗 [Edit in Builder.io](https://builder.io/app/projects/69e07a308d5a40efb30b9764ad603509/zenith-haven)

👀 [Preview Link](https://69e07a308d5a40efb30b9764ad603509-zenith-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>69e07a308d5a40efb30b9764ad603509</projectId>-->
<!--<branchName>zenith-haven</branchName>-->