### PR TITLE
Fix acid warning modal persistence after "Got it" click

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -127,6 +127,13 @@ export const Equipment: React.FC<EquipmentProps> = ({
     }
   });
 
+  // Listen for global dismissal events so all Equipment components update
+  React.useEffect(() => {
+    const handler = () => setAcidWarningDismissed(true);
+    window.addEventListener('oxalicAcidWarningDismissed', handler);
+    return () => window.removeEventListener('oxalicAcidWarningDismissed', handler);
+  }, []);
+
   React.useEffect(() => {
     if (acidWarningDismissed) setShowAcidWarning(false);
   }, [acidWarningDismissed]);

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -117,7 +117,9 @@ export const Equipment: React.FC<EquipmentProps> = ({
     e.stopPropagation();
   }, []);
 
-  const getEquipmentContent = () => {
+  const [showAcidWarning, setShowAcidWarning] = React.useState(false);
+
+    const getEquipmentContent = () => {
     const totalVolume = chemicals.reduce((sum, chemical) => sum + chemical.amount, 0);
 
     switch (equipmentIdentifier) {
@@ -142,11 +144,34 @@ export const Equipment: React.FC<EquipmentProps> = ({
             )}
             {oxalicAcid && (
               <div className="mt-2 text-xs">
-                <div className="bg-black text-green-400 px-2 py-1 rounded font-mono inline-block">
+                <div
+                  role="button"
+                  tabIndex={0}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (stepId === 3) setShowAcidWarning(true);
+                  }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && stepId === 3) setShowAcidWarning(true); }}
+                  className="bg-black text-green-400 px-2 py-1 rounded font-mono inline-block cursor-pointer"
+                >
                   {(oxalicAcid.amount / 1000).toFixed(4)} g
                 </div>
               </div>
             )}
+
+            {/* Acid added warning modal */}
+            {showAcidWarning && (
+              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+                <div className="bg-white rounded-lg shadow-lg max-w-md w-full p-6">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Be careful!</h3>
+                  <p className="text-sm text-gray-700 mb-4">Be careful while you add the acid into the machine to tare! Make sure you see the calculator and check the amount of acid required!</p>
+                  <div className="flex justify-end">
+                    <Button variant="default" onClick={() => setShowAcidWarning(false)}>Got it</Button>
+                  </div>
+                </div>
+              </div>
+            )}
+
           </div>
         );
 

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -467,6 +467,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   <Button onClick={() => {
                     try { localStorage.setItem('oxalicAcidWarningDismissed','true'); } catch (_) {}
                     setAcidWarningDismissed(true);
+                    // notify other instances
+                    try { window.dispatchEvent(new Event('oxalicAcidWarningDismissed')); } catch (_) {}
                     setShowAcidWarning(false);
                   }}>Got it</Button>
                 </div>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -545,10 +545,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
                 <div className="mt-4 flex items-center justify-end space-x-3">
                   <Button variant="outline" onClick={() => setShowAcidWarning(false)}>Close</Button>
                   <Button onClick={() => {
-                    try { localStorage.setItem('oxalicAcidWarningDismissed','true'); } catch (_) {}
                     setAcidWarningDismissed(true);
-                    // notify other instances
-                    try { window.dispatchEvent(new Event('oxalicAcidWarningDismissed')); } catch (_) {}
+                    persistAcidWarningDismissed(true);
                     setShowAcidWarning(false);
                   }}>Got it</Button>
                 </div>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -160,19 +160,6 @@ export const Equipment: React.FC<EquipmentProps> = ({
               </div>
             )}
 
-            {/* Acid added warning modal */}
-            {showAcidWarning && (
-              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-                <div className="bg-white rounded-lg shadow-lg max-w-md w-full p-6">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Be careful!</h3>
-                  <p className="text-sm text-gray-700 mb-4">Be careful while you add the acid into the machine to tare! Make sure you see the calculator and check the amount of acid required!</p>
-                  <div className="flex justify-end">
-                    <Button variant="default" onClick={() => setShowAcidWarning(false)}>Got it</Button>
-                  </div>
-                </div>
-              </div>
-            )}
-
           </div>
         );
 

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -476,10 +476,12 @@ export const Equipment: React.FC<EquipmentProps> = ({
       }}
       onMouseDown={handleMouseDown}
       onClick={(e) => {
-        // If user clicks equipment containing oxalic acid during step 3, show warning
-        if (chemicals.some(c => c.id === 'oxalic_acid') && stepId === 3) {
+        if (chemicals.some((c) => c.id === "oxalic_acid") && stepId === 3) {
           e.stopPropagation();
-          try { const dismissed = typeof window !== 'undefined' && localStorage.getItem('oxalicAcidWarningDismissed') === 'true'; if (!dismissed) setShowAcidWarning(true); } catch (_) { if (!acidWarningDismissed) setShowAcidWarning(true); }
+          const dismissed = acidWarningDismissed || readAcidWarningDismissed();
+          if (!dismissed) {
+            setShowAcidWarning(true);
+          }
         }
       }}
       onDrop={handleDrop}

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -243,9 +243,21 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   tabIndex={0}
                   onClick={(e) => {
                     e.stopPropagation();
-                    try { const dismissed = typeof window !== 'undefined' && localStorage.getItem('oxalicAcidWarningDismissed') === 'true'; if (stepId === 3 && !dismissed) setShowAcidWarning(true); } catch (_) { if (stepId === 3 && !acidWarningDismissed) setShowAcidWarning(true); }
+                    if (stepId === 3) {
+                      const dismissed = acidWarningDismissed || readAcidWarningDismissed();
+                      if (!dismissed) {
+                        setShowAcidWarning(true);
+                      }
+                    }
                   }}
-                  onKeyDown={(e) => { if (e.key === 'Enter' && stepId === 3 && !acidWarningDismissed) setShowAcidWarning(true); }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && stepId === 3) {
+                      const dismissed = acidWarningDismissed || readAcidWarningDismissed();
+                      if (!dismissed) {
+                        setShowAcidWarning(true);
+                      }
+                    }
+                  }}
                   className="bg-black text-green-400 px-2 py-1 rounded font-mono inline-block cursor-pointer"
                 >
                   {(oxalicAcid.amount / 1000).toFixed(4)} g

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -442,12 +442,29 @@ export const Equipment: React.FC<EquipmentProps> = ({
 
       {/* Acid added warning modal - rendered at component root so it appears regardless of equipment type */}
       {showAcidWarning && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-          <div className="bg-white rounded-lg shadow-lg max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">Be careful!</h3>
-            <p className="text-sm text-gray-700 mb-4">Be careful while you add the acid into the machine to tare! Make sure you see the calculator and check the amount of acid required!</p>
-            <div className="flex justify-end">
-              <Button variant="default" onClick={() => setShowAcidWarning(false)}>Got it</Button>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 p-4" role="dialog" aria-modal="true" aria-label="Acid caution">
+          <div className="bg-white rounded-2xl shadow-2xl max-w-xl w-full p-6 transform transition-all">
+            <div className="flex items-start space-x-4">
+              <div className="flex-shrink-0">
+                <div className="w-12 h-12 rounded-full bg-yellow-100 flex items-center justify-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6 text-yellow-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </div>
+              </div>
+              <div className="flex-1">
+                <h3 className="text-lg font-semibold text-gray-900">Caution</h3>
+                <p className="mt-2 text-sm text-gray-700">Be careful while you add the acid into the machine to tare. Make sure you open the calculator and verify the required amount before proceeding.</p>
+                <div className="mt-4 flex items-center justify-end space-x-3">
+                  <Button variant="outline" onClick={() => setShowAcidWarning(false)}>Close</Button>
+                  <Button onClick={() => {
+                    try { localStorage.setItem('oxalicAcidWarningDismissed','true'); } catch (_) {}
+                    setAcidWarningDismissed(true);
+                    setShowAcidWarning(false);
+                  }}>Got it</Button>
+                </div>
+                <p className="mt-3 text-xs text-gray-500">This message will not show again after you click "Got it".</p>
+              </div>
             </div>
           </div>
         </div>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -399,9 +399,9 @@ export const Equipment: React.FC<EquipmentProps> = ({
       onMouseDown={handleMouseDown}
       onClick={(e) => {
         // If user clicks equipment containing oxalic acid during step 3, show warning
-        if (chemicals.some(c => c.id === 'oxalic_acid') && stepId === 3 && !acidWarningDismissed) {
+        if (chemicals.some(c => c.id === 'oxalic_acid') && stepId === 3) {
           e.stopPropagation();
-          setShowAcidWarning(true);
+          try { const dismissed = typeof window !== 'undefined' && localStorage.getItem('oxalicAcidWarningDismissed') === 'true'; if (!dismissed) setShowAcidWarning(true); } catch (_) { if (!acidWarningDismissed) setShowAcidWarning(true); }
         }
       }}
       onDrop={handleDrop}

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -370,18 +370,25 @@ export const Equipment: React.FC<EquipmentProps> = ({
         zIndex: isDragging ? 1000 : 10,
       }}
       onMouseDown={handleMouseDown}
+      onClick={(e) => {
+        // If user clicks equipment containing oxalic acid during step 3, show warning
+        if (chemicals.some(c => c.id === 'oxalic_acid') && stepId === 3) {
+          e.stopPropagation();
+          setShowAcidWarning(true);
+        }
+      }}
       onDrop={handleDrop}
       onDragOver={handleDragOver}
       onMouseEnter={() => setShowDetails(true)}
       onMouseLeave={() => setShowDetails(false)}
     >
       {getEquipmentContent()}
-      
+
       {/* Action Button */}
       <div className="mt-2">
         {getActionButton()}
       </div>
-      
+
       {/* Remove Button */}
       {onRemove && (
         <button
@@ -394,15 +401,15 @@ export const Equipment: React.FC<EquipmentProps> = ({
           ×
         </button>
       )}
-      
+
       {/* Details Tooltip */}
       {showDetails && chemicals.length > 0 && (
         <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 bg-black text-white text-xs rounded p-2 whitespace-nowrap z-50">
           <div className="space-y-1">
             {chemicals.map((chemical, idx) => (
               <div key={idx} className="flex items-center space-x-2">
-                <div 
-                  className="w-2 h-2 rounded-full" 
+                <div
+                  className="w-2 h-2 rounded-full"
                   style={{ backgroundColor: chemical.color }}
                 />
                 <span>{chemical.name}: {chemical.amount}g</span>
@@ -410,6 +417,19 @@ export const Equipment: React.FC<EquipmentProps> = ({
             ))}
           </div>
           <div className="absolute top-full left-1/2 transform -translate-x-1/2 border-4 border-transparent border-t-black" />
+        </div>
+      )}
+
+      {/* Acid added warning modal - rendered at component root so it appears regardless of equipment type */}
+      {showAcidWarning && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+          <div className="bg-white rounded-lg shadow-lg max-w-md w-full p-6">
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">Be careful!</h3>
+            <p className="text-sm text-gray-700 mb-4">Be careful while you add the acid into the machine to tare! Make sure you see the calculator and check the amount of acid required!</p>
+            <div className="flex justify-end">
+              <Button variant="default" onClick={() => setShowAcidWarning(false)}>Got it</Button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -119,6 +119,26 @@ export const Equipment: React.FC<EquipmentProps> = ({
   }, []);
 
   const [showAcidWarning, setShowAcidWarning] = React.useState(false);
+  const [acidWarningDismissed, setAcidWarningDismissed] = React.useState<boolean>(() => {
+    try {
+      return typeof window !== 'undefined' && localStorage.getItem('oxalicAcidWarningDismissed') === 'true';
+    } catch (_) {
+      return false;
+    }
+  });
+
+  React.useEffect(() => {
+    if (acidWarningDismissed) setShowAcidWarning(false);
+  }, [acidWarningDismissed]);
+
+  React.useEffect(() => {
+    if (!showAcidWarning) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowAcidWarning(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [showAcidWarning]);
 
     const getEquipmentContent = () => {
     const totalVolume = chemicals.reduce((sum, chemical) => sum + chemical.amount, 0);

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -9,6 +9,8 @@ import StirringAnimation from "./StirringAnimation";
 import DissolutionAnimation from "./DissolutionAnimation";
 import type { EquipmentPosition, SolutionPreparationState } from "../types";
 
+import { Button } from "@/components/ui/button";
+
 interface EquipmentProps {
   id: string;
   name: string;
@@ -32,6 +34,7 @@ interface EquipmentProps {
   onRemove?: (id: string) => void;
   preparationState?: SolutionPreparationState;
   onAction?: (action: string) => void;
+  stepId?: number;
 }
 
 export const Equipment: React.FC<EquipmentProps> = ({

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -11,6 +11,50 @@ import type { EquipmentPosition, SolutionPreparationState } from "../types";
 
 import { Button } from "@/components/ui/button";
 
+const ACID_WARNING_STORAGE_KEY = "oxalicAcidWarningDismissed";
+const ACID_WARNING_EVENT = "oxalicAcidWarningDismissed";
+
+let acidWarningMemoryValue = false;
+
+const readAcidWarningDismissed = (): boolean => {
+  if (typeof window === "undefined") {
+    return acidWarningMemoryValue;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(ACID_WARNING_STORAGE_KEY);
+    if (stored !== null) {
+      acidWarningMemoryValue = stored === "true";
+    }
+  } catch {}
+
+  return acidWarningMemoryValue;
+};
+
+const persistAcidWarningDismissed = (dismissed: boolean) => {
+  const previous = acidWarningMemoryValue;
+  acidWarningMemoryValue = dismissed;
+
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (dismissed) {
+      window.localStorage.setItem(ACID_WARNING_STORAGE_KEY, "true");
+    } else {
+      window.localStorage.removeItem(ACID_WARNING_STORAGE_KEY);
+    }
+  } catch {}
+
+  if (previous !== dismissed) {
+    try {
+      window.dispatchEvent(new CustomEvent<boolean>(ACID_WARNING_EVENT, { detail: dismissed }));
+    } catch {}
+  }
+};
+
+
 interface EquipmentProps {
   id: string;
   name: string;

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -170,9 +170,9 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   tabIndex={0}
                   onClick={(e) => {
                     e.stopPropagation();
-                    if (stepId === 3) setShowAcidWarning(true);
+                    if (stepId === 3 && !acidWarningDismissed) setShowAcidWarning(true);
                   }}
-                  onKeyDown={(e) => { if (e.key === 'Enter' && stepId === 3) setShowAcidWarning(true); }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && stepId === 3 && !acidWarningDismissed) setShowAcidWarning(true); }}
                   className="bg-black text-green-400 px-2 py-1 rounded font-mono inline-block cursor-pointer"
                 >
                   {(oxalicAcid.amount / 1000).toFixed(4)} g

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -392,7 +392,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
       onMouseDown={handleMouseDown}
       onClick={(e) => {
         // If user clicks equipment containing oxalic acid during step 3, show warning
-        if (chemicals.some(c => c.id === 'oxalic_acid') && stepId === 3) {
+        if (chemicals.some(c => c.id === 'oxalic_acid') && stepId === 3 && !acidWarningDismissed) {
           e.stopPropagation();
           setShowAcidWarning(true);
         }

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -177,7 +177,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   tabIndex={0}
                   onClick={(e) => {
                     e.stopPropagation();
-                    if (stepId === 3 && !acidWarningDismissed) setShowAcidWarning(true);
+                    try { const dismissed = typeof window !== 'undefined' && localStorage.getItem('oxalicAcidWarningDismissed') === 'true'; if (stepId === 3 && !dismissed) setShowAcidWarning(true); } catch (_) { if (stepId === 3 && !acidWarningDismissed) setShowAcidWarning(true); }
                   }}
                   onKeyDown={(e) => { if (e.key === 'Enter' && stepId === 3 && !acidWarningDismissed) setShowAcidWarning(true); }}
                   className="bg-black text-green-400 px-2 py-1 rounded font-mono inline-block cursor-pointer"

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -50,6 +50,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
   onRemove,
   preparationState,
   onAction,
+  stepId,
 }) => {
   const [isDragging, setIsDragging] = useState(false);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -325,7 +325,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
       case 2:
         return "drag the oxalic acid dihydrate and spatula into the workspace";
       case 3:
-        return "drag the oxalic acid dihydrate into the workspace and place it on the balance.";
+        return "drag the oxalic acid dihydrate into the workspace and click on the acid to add in the boat to tare";
       case 4:
         return "Transfer the dissolved solution to a volumetric flask";
       case 5:

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -466,6 +466,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                     onRemove={handleEquipmentRemove}
                     preparationState={preparationState}
                     onAction={handleEquipmentAction}
+                    stepId={step.id}
                   />
                 );
               }

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -495,6 +495,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                     onRemove={handleEquipmentRemove}
                     preparationState={preparationState}
                     onAction={handleEquipmentAction}
+                    stepId={step.id}
                   />
                 );
               }

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -516,6 +516,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                     onRemove={handleEquipmentRemove}
                     preparationState={preparationState}
                     onAction={handleEquipmentAction}
+                    stepId={step.id}
                   />
                 );
               }


### PR DESCRIPTION
## Purpose
The user reported that the acid warning popup message continues to show even after clicking the "Got it" button. The modal should be permanently dismissed once the user acknowledges it by clicking "Got it".

## Code changes
- Added localStorage-based persistence system to track when the acid warning has been dismissed
- Implemented `readAcidWarningDismissed()` and `persistAcidWarningDismissed()` functions to manage warning state
- Added cross-tab synchronization using custom events and storage events
- Modified the "Got it" button to permanently dismiss the warning by setting the dismissed state in localStorage
- Added stepId prop to Equipment component to control when the warning should appear (step 3 only)
- Updated instruction text for step 3 to be more specific about clicking the acid
- Added keyboard support (Escape key) to close the modalTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 72`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1b0ef527fb994b54ac9d390c889f420a/nova-den)

👀 [Preview Link](https://1b0ef527fb994b54ac9d390c889f420a-nova-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1b0ef527fb994b54ac9d390c889f420a</projectId>-->
<!--<branchName>nova-den</branchName>-->