### PR TITLE
Add calculator reminder popup for oxalic acid equipment

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Chemical.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Chemical.tsx
@@ -152,16 +152,16 @@ export const Chemical: React.FC<ChemicalProps> = ({
               <h3 className="text-lg font-semibold text-gray-900">Reminder</h3>
               <p className="text-sm text-gray-700">Before adding the amount of acid into the boat make sure you open the calculator once!</p>
               <div className="flex items-center justify-center space-x-3 pt-2">
-                <button
-                  type="button"
-                  className="px-4 py-2 rounded-md border border-blue-200 text-blue-600 text-sm font-medium hover:bg-blue-50"
+                <Button
+                  variant="outline"
                   onClick={(e) => {
                     e.stopPropagation();
                     setShowReminder(false);
                   }}
+                  className="text-blue-600 border-blue-200 hover:bg-blue-50"
                 >
                   Close
-                </button>
+                </Button>
               </div>
             </div>
           </div>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Chemical.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Chemical.tsx
@@ -27,12 +27,14 @@ export const Chemical: React.FC<ChemicalProps> = ({
 }) => {
   const [dragAmount, setDragAmount] = React.useState(volume || 25);
 
+  const [showReminder, setShowReminder] = React.useState(false);
+
   const handleDragStart = (e: React.DragEvent) => {
     if (disabled) {
       e.preventDefault();
       return;
     }
-    
+
     e.dataTransfer.setData("text/plain", JSON.stringify({
       id,
       name,
@@ -45,6 +47,17 @@ export const Chemical: React.FC<ChemicalProps> = ({
     e.dataTransfer.effectAllowed = "copy";
   };
 
+  const handleCardClick = () => {
+    if (disabled) {
+      return;
+    }
+    onSelect(id);
+
+    if (id === "oxalic_acid") {
+      setShowReminder(true);
+    }
+  };
+
   return (
     <div
       className={`p-4 rounded-lg border-2 cursor-pointer transition-all duration-200 ${
@@ -54,7 +67,7 @@ export const Chemical: React.FC<ChemicalProps> = ({
           ? "border-gray-200 bg-gray-50 opacity-50 cursor-not-allowed"
           : "border-gray-300 bg-white hover:border-blue-300 hover:shadow-sm"
       }`}
-      onClick={() => !disabled && onSelect(id)}
+      onClick={handleCardClick}
       draggable={!disabled}
       onDragStart={handleDragStart}
     >

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Chemical.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Chemical.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Button } from "@/components/ui/button";
 
 interface ChemicalProps {
   id: string;

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Chemical.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Chemical.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Button } from "@/components/ui/button";
 
 interface ChemicalProps {
   id: string;
@@ -28,14 +27,12 @@ export const Chemical: React.FC<ChemicalProps> = ({
 }) => {
   const [dragAmount, setDragAmount] = React.useState(volume || 25);
 
-  const [showReminder, setShowReminder] = React.useState(false);
-
   const handleDragStart = (e: React.DragEvent) => {
     if (disabled) {
       e.preventDefault();
       return;
     }
-
+    
     e.dataTransfer.setData("text/plain", JSON.stringify({
       id,
       name,
@@ -48,17 +45,6 @@ export const Chemical: React.FC<ChemicalProps> = ({
     e.dataTransfer.effectAllowed = "copy";
   };
 
-  const handleCardClick = () => {
-    if (disabled) {
-      return;
-    }
-    onSelect(id);
-
-    if (id === "oxalic_acid") {
-      setShowReminder(true);
-    }
-  };
-
   return (
     <div
       className={`p-4 rounded-lg border-2 cursor-pointer transition-all duration-200 ${
@@ -68,7 +54,7 @@ export const Chemical: React.FC<ChemicalProps> = ({
           ? "border-gray-200 bg-gray-50 opacity-50 cursor-not-allowed"
           : "border-gray-300 bg-white hover:border-blue-300 hover:shadow-sm"
       }`}
-      onClick={handleCardClick}
+      onClick={() => !disabled && onSelect(id)}
       draggable={!disabled}
       onDragStart={handleDragStart}
     >
@@ -139,34 +125,6 @@ export const Chemical: React.FC<ChemicalProps> = ({
           </div>
         )}
       </div>
-
-      {showReminder && id === "oxalic_acid" && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 p-4" role="dialog" aria-modal="true" aria-label="Calculator reminder" onClick={(e) => { e.stopPropagation(); setShowReminder(false); }}>
-          <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6" onClick={(e) => e.stopPropagation()}>
-            <div className="space-y-3 text-center">
-              <div className="mx-auto w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-              </div>
-              <h3 className="text-lg font-semibold text-gray-900">Reminder</h3>
-              <p className="text-sm text-gray-700">Before adding the amount of acid into the boat make sure you open the calculator once!</p>
-              <div className="flex items-center justify-center space-x-3 pt-2">
-                <Button
-                  variant="outline"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setShowReminder(false);
-                  }}
-                  className="text-blue-600 border-blue-200 hover:bg-blue-50"
-                >
-                  Close
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Chemical.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Chemical.tsx
@@ -138,6 +138,34 @@ export const Chemical: React.FC<ChemicalProps> = ({
           </div>
         )}
       </div>
+
+      {showReminder && id === "oxalic_acid" && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 p-4" role="dialog" aria-modal="true" aria-label="Calculator reminder" onClick={(e) => { e.stopPropagation(); setShowReminder(false); }}>
+          <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6" onClick={(e) => e.stopPropagation()}>
+            <div className="space-y-3 text-center">
+              <div className="mx-auto w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center">
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900">Reminder</h3>
+              <p className="text-sm text-gray-700">Before adding the amount of acid into the boat make sure you open the calculator once!</p>
+              <div className="flex items-center justify-center space-x-3 pt-2">
+                <button
+                  type="button"
+                  className="px-4 py-2 rounded-md border border-blue-200 text-blue-600 text-sm font-medium hover:bg-blue-50"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setShowReminder(false);
+                  }}
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -529,8 +529,14 @@ export const Equipment: React.FC<EquipmentProps> = ({
 
       {/* Acid added warning modal - rendered at component root so it appears regardless of equipment type */}
       {showAcidWarning && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 p-4" role="dialog" aria-modal="true" aria-label="Acid caution">
-          <div className="bg-white rounded-2xl shadow-2xl max-w-xl w-full p-6 transform transition-all">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Acid caution"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="bg-white rounded-2xl shadow-2xl max-w-xl w-full p-6 transform transition-all" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-start space-x-4">
               <div className="flex-shrink-0">
                 <div className="w-12 h-12 rounded-full bg-yellow-100 flex items-center justify-center">
@@ -543,12 +549,8 @@ export const Equipment: React.FC<EquipmentProps> = ({
                 <h3 className="text-lg font-semibold text-gray-900">Caution</h3>
                 <p className="mt-2 text-sm text-gray-700">Be careful while you add the acid into the machine to tare. Make sure you open the calculator and verify the required amount before proceeding.</p>
                 <div className="mt-4 flex items-center justify-end space-x-3">
-                  <Button variant="outline" onClick={() => setShowAcidWarning(false)}>Close</Button>
-                  <Button onClick={() => {
-                    setAcidWarningDismissed(true);
-                    persistAcidWarningDismissed(true);
-                    setShowAcidWarning(false);
-                  }}>Got it</Button>
+                  <Button variant="outline" onClick={(e) => { e.stopPropagation(); setShowAcidWarning(false); }}>Close</Button>
+                  <Button onClick={(e) => { e.stopPropagation(); setAcidWarningDismissed(true); persistAcidWarningDismissed(true); setShowAcidWarning(false); }}>Got it</Button>
                 </div>
                 <p className="mt-3 text-xs text-gray-500">This message will not show again after you click "Got it".</p>
               </div>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -476,8 +476,13 @@ export const Equipment: React.FC<EquipmentProps> = ({
       }}
       onMouseDown={handleMouseDown}
       onClick={(e) => {
+        // Only open the acid warning when the user explicitly clicked
+        // the weight element (data-open-acid-warning). This prevents
+        // clicks coming from the modal or other children from re-opening it.
+        const opener = (e.target as HTMLElement).closest('[data-open-acid-warning="true"]');
+        if (!opener) return;
+
         if (chemicals.some((c) => c.id === "oxalic_acid") && stepId === 3) {
-          e.stopPropagation();
           const dismissed = acidWarningDismissed || readAcidWarningDismissed();
           if (!dismissed) {
             setShowAcidWarning(true);

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -337,7 +337,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
           <div className="relative flex justify-center">
             <button
               type="button"
-              className="flex items-center justify-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              className="flex items-center justify-center rounded-full bg-transparent p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
               data-open-acid-reminder="true"
               onClick={(event) => {
                 event.stopPropagation();
@@ -350,6 +350,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
               {icon}
               <span className="sr-only">Open calculator reminder</span>
             </button>
+            <p className="mt-2 text-xs text-gray-700">{name}</p>
           </div>
         );
 

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -343,6 +343,9 @@ export const Equipment: React.FC<EquipmentProps> = ({
                 event.stopPropagation();
                 if (stepId === 3) {
                   setShowCalculatorReminder(true);
+                  try {
+                    window.dispatchEvent(new CustomEvent('oxalicCalculatorReminder'));
+                  } catch {}
                 }
               }}
               onMouseDown={(event) => event.stopPropagation()}

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -241,6 +241,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
                 <div
                   role="button"
                   tabIndex={0}
+                  data-open-acid-warning="true"
                   onClick={(e) => {
                     e.stopPropagation();
                     if (stepId === 3) {

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -91,6 +91,17 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
     };
   }, []);
 
+  // Listen for global reminder events triggered by equipment components
+  useEffect(() => {
+    const handler = () => {
+      showMessage("Before adding the amount of acid into the boat make sure you open the calculator once!");
+    };
+    window.addEventListener("oxalicCalculatorReminder", handler as EventListener);
+    return () => {
+      window.removeEventListener("oxalicCalculatorReminder", handler as EventListener);
+    };
+  }, [showMessage]);
+
   useEffect(() => {
     if (isRunning) {
       const tempInterval = setInterval(() => {


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses issues with the oxalic acid standardization experiment where users needed a reminder to open the calculator before adding acid to the boat. Users reported that "nothing works" and specifically requested a popup message to guide them through the proper workflow.

## Code changes

- **Added calculator reminder modal**: Created a new popup that displays "Before adding the amount of acid into the boat make sure you open the calculator once!" when users click on the oxalic acid equipment icon in step 3
- **Enhanced oxalic acid equipment handling**: Added specific case handling for oxalic_acid equipment type with dedicated click handler and reminder state management
- **Improved event handling**: Added keyboard support (Escape key) to dismiss the reminder modal and proper event propagation control
- **Added global event system**: Implemented custom event dispatching to trigger reminder messages from equipment components to the workbench
- **Updated modal accessibility**: Enhanced existing acid warning modal with proper click event handling and accessibility attributes

The changes ensure users receive proper guidance when working with oxalic acid equipment, improving the overall user experience and reducing confusion during the experiment workflow.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 75`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1b0ef527fb994b54ac9d390c889f420a/zen-garden)

👀 [Preview Link](https://1b0ef527fb994b54ac9d390c889f420a-zen-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1b0ef527fb994b54ac9d390c889f420a</projectId>-->
<!--<branchName>zen-garden</branchName>-->