### PR TITLE
Remove analytical balance from workspace on step 3→4

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
@@ -569,6 +569,18 @@ function OxalicAcidVirtualLab({
     return () => window.removeEventListener('oxalic_image_shown', handler);
   }, [step.id, onStepComplete]);
 
+  // Remove analytical balance from the workspace only when advancing from step 3 to step 4.
+  // Do NOT notify the parent so the equipment palette remains unchanged.
+  const prevStepRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (prevStepRef.current === 3 && step.id === 4) {
+      setEquipmentPositions(prev => prev.filter(pos => {
+        const key = (pos.typeId ?? pos.id).toString().toLowerCase();
+        return !key.includes("analytical_balance");
+      }));
+    }
+    prevStepRef.current = step.id;
+  }, [step.id]);
 
   const canProceed = useCallback(() => {
     switch (step.id) {


### PR DESCRIPTION
## Purpose
Remove the analytical balance from the workspace when transitioning from step 3 to step 4, while keeping it available in the equipment section for potential reuse.

## Code changes
- Added a `useEffect` hook with step transition detection using `useRef` to track previous step
- Filters out analytical balance from `equipmentPositions` state when moving from step 3 to step 4
- Uses string matching on equipment keys to identify analytical balance items
- Preserves equipment palette by only modifying workspace positions, not notifying parent component

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 83`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1b0ef527fb994b54ac9d390c889f420a/stellar-forge)

👀 [Preview Link](https://1b0ef527fb994b54ac9d390c889f420a-stellar-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1b0ef527fb994b54ac9d390c889f420a</projectId>-->
<!--<branchName>stellar-forge</branchName>-->