### PR TITLE
Add quiz functionality to ammonium buffer experiment

### DIFF
--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -6,7 +6,7 @@ import { WorkBench } from "@/experiments/EquilibriumShift/components/WorkBench";
 import { Equipment } from "./Equipment";
 import { AB_LAB_EQUIPMENT } from "./Equipment";
 import { COLORS, INITIAL_TESTTUBE, GUIDED_STEPS, ANIMATION } from "../constants";
-import { Beaker, Info, Wrench, CheckCircle, ArrowRight, TestTube, Undo2, TrendingUp, Clock, Home } from "lucide-react";
+import { Beaker, Info, Wrench, CheckCircle, ArrowRight, ArrowLeft, TestTube, Undo2, TrendingUp, Clock, Home } from "lucide-react";
 import { Link } from "wouter";
 
 interface ExperimentMode {

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -8,6 +8,7 @@ import { AB_LAB_EQUIPMENT } from "./Equipment";
 import { COLORS, INITIAL_TESTTUBE, GUIDED_STEPS, ANIMATION } from "../constants";
 import { Beaker, Info, Wrench, CheckCircle, ArrowRight, ArrowLeft, TestTube, Undo2, TrendingUp, Clock, Home } from "lucide-react";
 import { Link } from "wouter";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface ExperimentMode {
   current: 'guided';

--- a/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/AmmoniumBuffer/components/VirtualLab.tsx
@@ -81,8 +81,27 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
   }, []);
   const [ammoniumInitialPH, setAmmoniumInitialPH] = useState<number | null>(null);
   const [ammoniumAfterPH, setAmmoniumAfterPH] = useState<number | null>(null);
+  // Quiz modal state
+  const [showQuizModal, setShowQuizModal] = useState(false);
+  const [quizSelections, setQuizSelections] = useState<{ q1?: string; q2?: string; q3?: string; q4?: string; q5?: string }>({});
+  const [quizSubmitted, setQuizSubmitted] = useState(false);
+  const [quizScore, setQuizScore] = useState<number | null>(null);
 
   useEffect(() => { setCurrentStep((mode.currentGuidedStep || 0) + 1); }, [mode.currentGuidedStep]);
+
+  const handleSelect = (q: 'q1'|'q2'|'q3'|'q4'|'q5', val: string) => {
+    setQuizSelections(prev => ({ ...prev, [q]: val }));
+  };
+
+  const submitQuiz = () => {
+    const correct: Record<string,string> = { q1: 'B', q2: 'B', q3: 'A', q4: 'B', q5: 'B' };
+    let score = 0;
+    (['q1','q2','q3','q4','q5'] as Array<'q1'|'q2'|'q3'|'q4'|'q5'>).forEach(k => { if (quizSelections[k] === correct[k]) score++; });
+    setQuizScore(score);
+    setQuizSubmitted(true);
+  };
+
+  const allAnswered = !!(quizSelections.q1 && quizSelections.q2 && quizSelections.q3 && quizSelections.q4 && quizSelections.q5);
 
 useEffect(() => {
   if (showResultsModal) {
@@ -776,8 +795,223 @@ useEffect(() => {
                 <span>Return to Experiments</span>
               </Button>
             </Link>
-            <Button onClick={() => setShowResultsModal(false)} className="bg-blue-500 hover:bg-blue-600 text-white">Close Analysis</Button>
+            <div className="flex items-center space-x-2">
+              <Button onClick={() => setShowQuizModal(true)} className="bg-amber-600 hover:bg-amber-700 text-white">QUIZ</Button>
+              <Button onClick={() => setShowResultsModal(false)} className="bg-blue-500 hover:bg-blue-600 text-white">Close Analysis</Button>
+            </div>
           </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Quiz Modal */}
+      <Dialog open={showQuizModal} onOpenChange={setShowQuizModal}>
+        <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto text-black">
+          <Card className="shadow-md">
+            <CardHeader>
+              <div className="flex items-center justify-between w-full">
+                <CardTitle className="text-2xl">NH4OH / NH4Cl — Quiz</CardTitle>
+                {quizSubmitted && (
+                  <div className="text-blue-600 font-semibold">Marks obtained ({quizScore} / 5)</div>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-6 quiz-content">
+                <section className="quiz-item">
+                  <h3 className="font-semibold">Q1. Why does the addition of NH₄Cl lower the pH of NH₄OH solution?</h3>
+                  <div className="mt-2 space-y-2">
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q1" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'A'} onChange={() => handleSelect('q1','A')} />
+                      <span>A) NH₄Cl reacts with water to produce OH⁻ ions</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q1" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'B'} onChange={() => handleSelect('q1','B')} />
+                      <span>B) NH₄⁺ ions increase, shifting NH₄⁺/NH₃ equilibrium toward NH₃ formation, reducing OH⁻ concentration</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q1" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'C'} onChange={() => handleSelect('q1','C')} />
+                      <span>C) NH₄Cl directly neutralizes NH₄OH</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q1" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'D'} onChange={() => handleSelect('q1','D')} />
+                      <span>D) NH₄Cl hydrolyzes to form HCl</span>
+                    </label>
+                  </div>
+                  {quizSubmitted && (() => {
+                    const correct = 'B';
+                    const selected = quizSelections.q1;
+                    const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                    return (
+                      <>
+                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) NH₄Cl reacts with water to produce OH⁻ ions' : selected === 'B' ? 'B) NH₄⁺ ions increase, shifting NH₄⁺/NH₃ equilibrium toward NH₃ formation, reducing OH⁻ concentration' : selected === 'C' ? 'C) NH₄Cl directly neutralizes NH₄OH' : selected === 'D' ? 'D) NH₄Cl hydrolyzes to form HCl' : ''}</div>
+                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: B) NH₄⁺ ions increase, shifting NH₄⁺/NH₃ equilibrium toward NH₃ formation, reducing OH⁻ concentration</div>
+                      </>
+                    );
+                  })()}
+                </section>
+
+                <section className="quiz-item">
+                  <h3 className="font-semibold">Q2. The NH₄⁺/NH₃ system acts as a buffer because:</h3>
+                  <div className="mt-2 space-y-2">
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q2" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'A'} onChange={() => handleSelect('q2','A')} />
+                      <span>A) Both NH₄⁺ and NH�� are strong acids and bases</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q2" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'B'} onChange={() => handleSelect('q2','B')} />
+                      <span>B) The conjugate acid–base pair resists pH changes on addition of small amounts of acids or bases</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q2" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'C'} onChange={() => handleSelect('q2','C')} />
+                      <span>C) NH₄OH is a strong base</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q2" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'D'} onChange={() => handleSelect('q2','D')} />
+                      <span>D) NH₄Cl is a strong electrolyte</span>
+                    </label>
+                  </div>
+                  {quizSubmitted && (() => {
+                    const correct = 'B';
+                    const selected = quizSelections.q2;
+                    const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                    return (
+                      <>
+                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) Both NH₄⁺ and NH₃ are strong acids and bases' : selected === 'B' ? 'B) The conjugate acid–base pair resists pH changes on addition of small amounts of acids or bases' : selected === 'C' ? 'C) NH₄OH is a strong base' : selected === 'D' ? 'D) NH₄Cl is a strong electrolyte' : ''}</div>
+                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: B) The conjugate acid–base pair resists pH changes on addition of small amounts of acids or bases</div>
+                      </>
+                    );
+                  })()}
+                </section>
+
+                <section className="quiz-item">
+                  <h3 className="font-semibold">Q3. In the Henderson–Hasselbalch equation for this system, which statement is true?</h3>
+                  <div className="mt-2 space-y-2">
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q3" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'A'} onChange={() => handleSelect('q3','A')} />
+                      <span>A) Increasing [NH₄⁺] lowers the pH</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q3" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'B'} onChange={() => handleSelect('q3','B')} />
+                      <span>B) Increasing [NH₄⁺] raises the pH</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q3" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'C'} onChange={() => handleSelect('q3','C')} />
+                      <span>C) pH is independent of [NH₄⁺] and [NH₃]</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q3" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'D'} onChange={() => handleSelect('q3','D')} />
+                      <span>D) It is only valid for strong acids and bases</span>
+                    </label>
+                  </div>
+                  {quizSubmitted && (() => {
+                    const correct = 'A';
+                    const selected = quizSelections.q3;
+                    const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                    return (
+                      <>
+                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) Increasing [NH₄⁺] lowers the pH' : selected === 'B' ? 'B) Increasing [NH₄⁺] raises the pH' : selected === 'C' ? 'C) pH is independent of [NH₄⁺] and [NH₃]' : selected === 'D' ? 'D) It is only valid for strong acids and bases' : ''}</div>
+                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: A) Increasing [NH₄⁺] lowers the pH</div>
+                      </>
+                    );
+                  })()}
+                </section>
+
+                <section className="quiz-item">
+                  <h3 className="font-semibold">Q4. Which factor primarily limits the buffering capacity of the NH₄⁺/NH₃ system?</h3>
+                  <div className="mt-2 space-y-2">
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q4" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'A'} onChange={() => handleSelect('q4','A')} />
+                      <span>A) The initial pH of NH₄OH</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q4" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'B'} onChange={() => handleSelect('q4','B')} />
+                      <span>B) The ratio [NH₃]/[NH₄⁺] approaching extreme values (&lt;0.1 or &gt;10)</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q4" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'C'} onChange={() => handleSelect('q4','C')} />
+                      <span>C) The temperature of the solution</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q4" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'D'} onChange={() => handleSelect('q4','D')} />
+                      <span>D) The solubility of NH₄Cl in water</span>
+                    </label>
+                  </div>
+                  {quizSubmitted && (() => {
+                    const correct = 'B';
+                    const selected = quizSelections.q4;
+                    const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                    return (
+                      <>
+                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) The initial pH of NH₄OH' : selected === 'B' ? 'B) The ratio [NH₃]/[NH₄⁺] approaching extreme values (<0.1 or >10)' : selected === 'C' ? 'C) The temperature of the solution' : selected === 'D' ? 'D) The solubility of NH₄Cl in water' : ''}</div>
+                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: B) The ratio [NH₃]/[NH₄⁺] approaching extreme values (&lt;0.1 or &gt;10)</div>
+                      </>
+                    );
+                  })()}
+                </section>
+
+                <section className="quiz-item">
+                  <h3 className="font-semibold">Q5. What happens to the pH if an excess amount of NH₄Cl is added beyond the buffer range?</h3>
+                  <div className="mt-2 space-y-2">
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q5" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'A'} onChange={() => handleSelect('q5','A')} />
+                      <span>A) pH remains constant</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q5" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'B'} onChange={() => handleSelect('q5','B')} />
+                      <span>B) pH decreases significantly toward acidic values</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q5" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'C'} onChange={() => handleSelect('q5','C')} />
+                      <span>C) pH increases</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q5" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'D'} onChange={() => handleSelect('q5','D')} />
+                      <span>D) Solution becomes strongly basic</span>
+                    </label>
+                  </div>
+                  {quizSubmitted && (() => {
+                    const correct = 'B';
+                    const selected = quizSelections.q5;
+                    const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                    return (
+                      <>
+                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) pH remains constant' : selected === 'B' ? 'B) pH decreases significantly toward acidic values' : selected === 'C' ? 'C) pH increases' : selected === 'D' ? 'D) Solution becomes strongly basic' : ''}</div>
+                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: B) pH decreases significantly toward acidic values</div>
+                      </>
+                    );
+                  })()}
+                </section>
+
+              </div>
+            </CardContent>
+
+            <div className="p-4 flex justify-between items-center">
+              <div className="flex items-center space-x-2">
+                <Button variant="outline" className="flex items-center" onClick={() => { setShowQuizModal(false); setShowResultsModal(true); }}>
+                  <ArrowLeft className="w-4 h-4 mr-2" /> Back to Experiment
+                </Button>
+                <Link href="/">
+                  <Button className="bg-gray-700 hover:bg-gray-800 text-white flex items-center px-4 py-2">
+                    Return to Experiments
+                  </Button>
+                </Link>
+              </div>
+
+              <div>
+                {!quizSubmitted ? (
+                  <>
+                    <Button variant="outline" onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); }}>Reset</Button>
+                    <Button onClick={() => { submitQuiz(); }} disabled={!allAnswered}>Submit</Button>
+                  </>
+                ) : (
+                  <>
+                    <Button variant="outline" onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); }}>Reset</Button>
+                    <Button onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); setShowQuizModal(false); }}>Close</Button>
+                  </>
+                )}
+              </div>
+            </div>
+          </Card>
         </DialogContent>
       </Dialog>
 

--- a/chemLab2-main/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
@@ -1068,13 +1068,229 @@ export default function VirtualLab({
                   <span>Return to Experiments</span>
                 </Button>
               </Link>
-              <Button
-                onClick={() => setShowResultsModal(false)}
-                className="bg-blue-500 hover:bg-blue-600 text-white"
-              >
-                Close Analysis
-              </Button>
+              <div className="flex items-center space-x-2">
+                <Button onClick={() => setShowQuizModal(true)} className="bg-amber-600 hover:bg-amber-700 text-white">QUIZ</Button>
+                <Button
+                  onClick={() => setShowResultsModal(false)}
+                  className="bg-blue-500 hover:bg-blue-600 text-white"
+                >
+                  Close Analysis
+                </Button>
+              </div>
             </div>
+          </DialogContent>
+        </Dialog>
+
+        {/* Quiz Modal */}
+        <Dialog open={showQuizModal} onOpenChange={setShowQuizModal}>
+          <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto text-black">
+            <Card className="shadow-md">
+              <CardHeader>
+                <div className="flex items-center justify-between w-full">
+                  <CardTitle className="text-2xl">Equilibrium Shift — Quiz</CardTitle>
+                  {quizSubmitted && (
+                    <div className="text-blue-600 font-semibold">Marks obtained ({quizScore} / 5)</div>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-6 quiz-content">
+
+                  <section className="quiz-item">
+                    <h3 className="font-semibold">Q1. The equilibrium between [Co(H₂O)₆]²⁺ and [CoCl₄]²⁻ is sensitive to chloride ion concentration. This is because:</h3>
+                    <div className="mt-2 space-y-2">
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q1" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'A'} onChange={() => handleSelect('q1','A')} />
+                        <span>A) Chloride ions act as a catalyst in the reaction</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q1" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'B'} onChange={() => handleSelect('q1','B')} />
+                        <span>B) Chloride ions form a complex with Co²⁺, shifting the equilibrium</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q1" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'C'} onChange={() => handleSelect('q1','C')} />
+                        <span>C) Chloride ions increase the solubility of CoCl₂</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q1" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'D'} onChange={() => handleSelect('q1','D')} />
+                        <span>D) Chloride ions change the oxidation state of cobalt</span>
+                      </label>
+                    </div>
+                    {quizSubmitted && (() => {
+                      const correct = 'B';
+                      const selected = quizSelections.q1;
+                      const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                      return (
+                        <>
+                          <div className={yourClass}>Your answer: {selected === 'A' ? 'A) Chloride ions act as a catalyst in the reaction' : selected === 'B' ? 'B) Chloride ions form a complex with Co²⁺, shifting the equilibrium' : selected === 'C' ? 'C) Chloride ions increase the solubility of CoCl₂' : selected === 'D' ? 'D) Chloride ions change the oxidation state of cobalt' : ''}</div>
+                          <div className="mt-2 text-sm text-green-700 font-medium">Answer: B) Chloride ions form a complex with Co²⁺, shifting the equilibrium</div>
+                        </>
+                      );
+                    })()}
+                  </section>
+
+                  <section className="quiz-item">
+                    <h3 className="font-semibold">Q2. Why does heating the solution favor formation of the blue [CoCl₄]²⁻ complex?</h3>
+                    <div className="mt-2 space-y-2">
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q2" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'A'} onChange={() => handleSelect('q2','A')} />
+                        <span>A) The forward reaction is exothermic, so heat drives it forward</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q2" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'B'} onChange={() => handleSelect('q2','B')} />
+                        <span>B) The forward reaction is endothermic, so heat drives it forward</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q2" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'C'} onChange={() => handleSelect('q2','C')} />
+                        <span>C) Heat increases the solubility of Cl⁻ ions</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q2" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'D'} onChange={() => handleSelect('q2','D')} />
+                        <span>D) Heat reduces water concentration</span>
+                      </label>
+                    </div>
+                    {quizSubmitted && (() => {
+                      const correct = 'B';
+                      const selected = quizSelections.q2;
+                      const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                      return (
+                        <>
+                          <div className={yourClass}>Your answer: {selected === 'A' ? 'A) The forward reaction is exothermic, so heat drives it forward' : selected === 'B' ? 'B) The forward reaction is endothermic, so heat drives it forward' : selected === 'C' ? 'C) Heat increases the solubility of Cl⁻ ions' : selected === 'D' ? 'D) Heat reduces water concentration' : ''}</div>
+                          <div className="mt-2 text-sm text-green-700 font-medium">Answer: B) The forward reaction is endothermic, so heat drives it forward</div>
+                        </>
+                      );
+                    })()}
+                  </section>
+
+                  <section className="quiz-item">
+                    <h3 className="font-semibold">Q3. When water is added to a blue [CoCl₄]²⁻ solution, the solution turns pink. This observation illustrates:</h3>
+                    <div className="mt-2 space-y-2">
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q3" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'A'} onChange={() => handleSelect('q3','A')} />
+                        <span>A) The principle of constant composition</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q3" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'B'} onChange={() => handleSelect('q3','B')} />
+                        <span>B) Le Chatelier’s principle — dilution shifts equilibrium toward [Co(H₂O)₆]²⁺</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q3" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'C'} onChange={() => handleSelect('q3','C')} />
+                        <span>C) The formation of a precipitate</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q3" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'D'} onChange={() => handleSelect('q3','D')} />
+                        <span>D) A redox reaction</span>
+                      </label>
+                    </div>
+                    {quizSubmitted && (() => {
+                      const correct = 'B';
+                      const selected = quizSelections.q3;
+                      const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                      return (
+                        <>
+                          <div className={yourClass}>Your answer: {selected === 'A' ? 'A) The principle of constant composition' : selected === 'B' ? 'B) Le Chatelier’s principle — dilution shifts equilibrium toward [Co(H₂O)₆]²⁺' : selected === 'C' ? 'C) The formation of a precipitate' : selected === 'D' ? 'D) A redox reaction' : ''}</div>
+                          <div className="mt-2 text-sm text-green-700 font-medium">Answer: B) Le Chatelier’s principle — dilution shifts equilibrium toward [Co(H₂O)₆]²⁺</div>
+                        </>
+                      );
+                    })()}
+                  </section>
+
+                  <section className="quiz-item">
+                    <h3 className="font-semibold">Q4. In the equilibrium ([Co(H₂O)₆]²⁺ + 4Cl⁻ ⇌ [CoCl₄]²⁻ + 6H₂O), increasing pressure would:</h3>
+                    <div className="mt-2 space-y-2">
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q4" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'A'} onChange={() => handleSelect('q4','A')} />
+                        <span>A) Shift equilibrium toward blue [CoCl₄]²⁻</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q4" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'B'} onChange={() => handleSelect('q4','B')} />
+                        <span>B) Shift equilibrium toward pink [Co(H₂O)₆]²⁺</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q4" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'C'} onChange={() => handleSelect('q4','C')} />
+                        <span>C) Have no effect because it’s a liquid phase reaction</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q4" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'D'} onChange={() => handleSelect('q4','D')} />
+                        <span>D) Cause decomposition of CoCl₂</span>
+                      </label>
+                    </div>
+                    {quizSubmitted && (() => {
+                      const correct = 'C';
+                      const selected = quizSelections.q4;
+                      const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                      return (
+                        <>
+                          <div className={yourClass}>Your answer: {selected === 'A' ? 'A) Shift equilibrium toward blue [CoCl₄]²⁻' : selected === 'B' ? 'B) Shift equilibrium toward pink [Co(H₂O)₆]²⁺' : selected === 'C' ? 'C) Have no effect because it’s a liquid phase reaction' : selected === 'D' ? 'D) Cause decomposition of CoCl₂' : ''}</div>
+                          <div className="mt-2 text-sm text-green-700 font-medium">Answer: C) Have no effect because it’s a liquid phase reaction</div>
+                        </>
+                      );
+                    })()}
+                  </section>
+
+                  <section className="quiz-item">
+                    <h3 className="font-semibold">Q5. Which statement best describes the type of chemical equilibrium in this experiment?</h3>
+                    <div className="mt-2 space-y-2">
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q5" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'A'} onChange={() => handleSelect('q5','A')} />
+                        <span>A) Acid-base equilibrium</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q5" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'B'} onChange={() => handleSelect('q5','B')} />
+                        <span>B) Precipitation equilibrium</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q5" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'C'} onChange={() => handleSelect('q5','C')} />
+                        <span>C) Complex ion formation equilibrium</span>
+                      </label>
+                      <label className="quiz-option flex items-start space-x-2">
+                        <input type="radio" name="q5" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'D'} onChange={() => handleSelect('q5','D')} />
+                        <span>D) Redox equilibrium</span>
+                      </label>
+                    </div>
+                    {quizSubmitted && (() => {
+                      const correct = 'C';
+                      const selected = quizSelections.q5;
+                      const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                      return (
+                        <>
+                          <div className={yourClass}>Your answer: {selected === 'A' ? 'A) Acid-base equilibrium' : selected === 'B' ? 'B) Precipitation equilibrium' : selected === 'C' ? 'C) Complex ion formation equilibrium' : selected === 'D' ? 'D) Redox equilibrium' : ''}</div>
+                          <div className="mt-2 text-sm text-green-700 font-medium">Answer: C) Complex ion formation equilibrium</div>
+                        </>
+                      );
+                    })()}
+                  </section>
+
+                </div>
+              </CardContent>
+
+              <div className="p-4 flex justify-between items-center">
+                <div className="flex items-center space-x-2">
+                  <Button variant="outline" className="flex items-center" onClick={() => { setShowQuizModal(false); setShowResultsModal(true); }}>
+                    <ArrowLeft className="w-4 h-4 mr-2" /> Back to Experiment
+                  </Button>
+                  <Link href="/">
+                    <Button className="bg-gray-700 hover:bg-gray-800 text-white flex items-center px-4 py-2">
+                      Return to Experiments
+                    </Button>
+                  </Link>
+                </div>
+
+                <div>
+                  {!quizSubmitted ? (
+                    <>
+                      <Button variant="outline" onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); }}>Reset</Button>
+                      <Button onClick={() => { submitQuiz(); }} disabled={!allAnswered}>Submit</Button>
+                    </>
+                  ) : (
+                    <>
+                      <Button variant="outline" onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); }}>Reset</Button>
+                      <Button onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); setShowQuizModal(false); }}>Close</Button>
+                    </>
+                  )}
+                </div>
+              </div>
+            </Card>
           </DialogContent>
         </Dialog>
 

--- a/chemLab2-main/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
@@ -79,6 +79,26 @@ export default function VirtualLab({
   const [observePulse, setObservePulse] = useState<boolean>(true);
   const [finalVolumeUsed, setFinalVolumeUsed] = useState<number | null>(null);
 
+  // Quiz modal state
+  const [showQuizModal, setShowQuizModal] = useState(false);
+  const [quizSelections, setQuizSelections] = useState<{ q1?: string; q2?: string; q3?: string; q4?: string; q5?: string }>({});
+  const [quizSubmitted, setQuizSubmitted] = useState(false);
+  const [quizScore, setQuizScore] = useState<number | null>(null);
+
+  const handleSelect = (q: 'q1'|'q2'|'q3'|'q4'|'q5', val: string) => {
+    setQuizSelections(prev => ({ ...prev, [q]: val }));
+  };
+
+  const submitQuiz = () => {
+    const correct: Record<string,string> = { q1: 'B', q2: 'B', q3: 'B', q4: 'C', q5: 'C' };
+    let score = 0;
+    (['q1','q2','q3','q4','q5'] as Array<'q1'|'q2'|'q3'|'q4'|'q5'>).forEach(k => { if (quizSelections[k] === correct[k]) score++; });
+    setQuizScore(score);
+    setQuizSubmitted(true);
+  };
+
+  const allAnswered = !!(quizSelections.q1 && quizSelections.q2 && quizSelections.q3 && quizSelections.q4 && quizSelections.q5);
+
   useEffect(() => {
     const handler = (e: any) => {
       const v = e?.detail?.volumeUsed;

--- a/chemLab2-main/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/EquilibriumShift/components/VirtualLab.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { FlaskConical, Beaker, Droplets, Info, ArrowRight, ArrowLeft, CheckCircle, Wrench, X, TrendingUp, Clock, Home } from "lucide-react";
 import { Link } from "wouter";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { WorkBench } from "./WorkBench";
 import { Equipment, LAB_EQUIPMENT } from "./Equipment";
 import { 

--- a/chemLab2-main/client/src/experiments/EquilibriumShift/data.ts
+++ b/chemLab2-main/client/src/experiments/EquilibriumShift/data.ts
@@ -1,6 +1,6 @@
 const EquilibriumShiftData = {
   id: 5,
-  title: "Equilibrium Shift: [Co(H₂O)₆]²⁺ vs Cl⁻ Ions",
+  title: "To study the shift in equilibrium between [Co(H2O)6]²+ and Cl- by changing the concentration of either ions.",
   description: "Interactive virtual lab to study equilibrium shifts between cobalt complexes. Observe dramatic color changes from pink to blue as you add HCl or water, demonstrating Le Chatelier's principle in real-time.",
   category: "Chemical Equilibrium",
   difficulty: "Intermediate",

--- a/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -84,6 +84,9 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
   const [quizSubmitted, setQuizSubmitted] = useState(false);
   const [quizScore, setQuizScore] = useState<number | null>(null);
 
+  // Helper: ensure all questions have an answer before enabling Submit
+  const allAnswered = !!(quizSelections.q1 && quizSelections.q2 && quizSelections.q3 && quizSelections.q4 && quizSelections.q5);
+
   // Clean up any scheduled timeouts on unmount
   useEffect(() => {
     return () => {
@@ -1058,8 +1061,8 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                   <ArrowLeft className="w-4 h-4 mr-2" /> Back to Experiment
                 </Button>
                 <Link href="/">
-                  <Button variant="outline" className="flex items-center">
-                    <ArrowLeft className="w-4 h-4 mr-2 rotate-180" /> Return to Experiments
+                  <Button className="bg-gray-700 hover:bg-gray-800 text-white flex items-center px-4 py-2">
+                    Return to Experiments
                   </Button>
                 </Link>
               </div>
@@ -1068,7 +1071,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
                 {!quizSubmitted ? (
                   <>
                     <Button variant="outline" onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); }}>Reset</Button>
-                    <Button onClick={() => { submitQuiz(); }}>Submit</Button>
+                    <Button onClick={() => { submitQuiz(); }} disabled={!allAnswered}>Submit</Button>
                   </>
                 ) : (
                   <>

--- a/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -80,7 +80,7 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
 
   // Quiz modal state
   const [showQuizModal, setShowQuizModal] = useState(false);
-  const [quizSelections, setQuizSelections] = useState<{ q1?: string; q2?: string; q3?: string }>({});
+  const [quizSelections, setQuizSelections] = useState<{ q1?: string; q2?: string; q3?: string; q4?: string; q5?: string }>({});
   const [quizSubmitted, setQuizSubmitted] = useState(false);
   const [quizScore, setQuizScore] = useState<number | null>(null);
 
@@ -478,14 +478,14 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
     setTestTube(prev => ({ ...prev, volume: 0, contents: [], colorHex: COLORS.CLEAR }));
   };
 
-  const handleSelect = (q: 'q1'|'q2'|'q3', val: string) => {
+  const handleSelect = (q: 'q1'|'q2'|'q3'|'q4'|'q5', val: string) => {
     setQuizSelections(prev => ({ ...prev, [q]: val }));
   };
 
   const submitQuiz = () => {
-    const correct: Record<string,string> = { q1: 'A', q2: 'A', q3: 'A' };
+    const correct: Record<string,string> = { q1: 'B', q2: 'C', q3: 'B', q4: 'A', q5: 'B' };
     let score = 0;
-    (['q1','q2','q3'] as Array<'q1'|'q2'|'q3'>).forEach(k => { if (quizSelections[k] === correct[k]) score++; });
+    (['q1','q2','q3','q4','q5'] as Array<'q1'|'q2'|'q3'|'q4'|'q5'>).forEach(k => { if (quizSelections[k] === correct[k]) score++; });
     setQuizScore(score);
     setQuizSubmitted(true);
   };
@@ -877,86 +877,178 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
               <div className="flex items-center justify-between w-full">
                 <CardTitle className="text-2xl">pH Comparison — Quiz</CardTitle>
                 {quizSubmitted && (
-                  <div className="text-blue-600 font-semibold">Marks obtained ({quizScore} / 3)</div>
+                  <div className="text-blue-600 font-semibold">Marks obtained ({quizScore} / 5)</div>
                 )}
               </div>
             </CardHeader>
             <CardContent>
               <div className="space-y-6 quiz-content">
+
                 <section className="quiz-item">
-                  <h3 className="font-semibold">Q1. Which solution is expected to be more acidic?</h3>
+                  <h3 className="font-semibold">Q1. The pH of 0.01 M CH₃COOH is higher than that of 0.01 M HCl mainly because:</h3>
                   <div className="mt-2 space-y-2">
                     <label className="quiz-option flex items-start space-x-2">
                       <input type="radio" name="q1" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'A'} onChange={() => handleSelect('q1','A')} />
-                      <span>A) 0.01 M HCl</span>
+                      <span>A) Acetic acid molecules are more concentrated</span>
                     </label>
                     <label className="quiz-option flex items-start space-x-2">
                       <input type="radio" name="q1" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'B'} onChange={() => handleSelect('q1','B')} />
-                      <span>B) 0.01 M CH3COOH</span>
+                      <span>B) Acetic acid dissociates only partially in water</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q1" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'C'} onChange={() => handleSelect('q1','C')} />
+                      <span>C) HCl has a smaller molar mass than CH₃COOH</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q1" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q1 === 'D'} onChange={() => handleSelect('q1','D')} />
+                      <span>D) HCl reacts with the indicator while CH₃COOH does not</span>
                     </label>
                   </div>
                   {quizSubmitted && (() => {
-                    const correct = 'A';
+                    const correct = 'B';
                     const selected = quizSelections.q1;
                     const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
                     return (
                       <>
-                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) 0.01 M HCl' : selected === 'B' ? 'B) 0.01 M CH3COOH' : ''}</div>
-                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: A) 0.01 M HCl</div>
+                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) Acetic acid molecules are more concentrated' : selected === 'B' ? 'B) Acetic acid dissociates only partially in water' : selected === 'C' ? 'C) HCl has a smaller molar mass than CH₃COOH' : selected === 'D' ? 'D) HCl reacts with the indicator while CH₃COOH does not' : ''}</div>
+                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: B) Acetic acid dissociates only partially in water</div>
                       </>
                     );
                   })()}
                 </section>
 
                 <section className="quiz-item">
-                  <h3 className="font-semibold">Q2. Expected indicator color for 0.01 M CH3COOH + Universal Indicator is:</h3>
+                  <h3 className="font-semibold">Q2. If the concentration of CH₃COOH is increased from 0.01 M to 0.1 M, what will happen to its pH?</h3>
                   <div className="mt-2 space-y-2">
                     <label className="quiz-option flex items-start space-x-2">
                       <input type="radio" name="q2" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'A'} onChange={() => handleSelect('q2','A')} />
-                      <span>A) Yellow/Orange (≈ pH 3–4)</span>
+                      <span>A) pH will remain unchanged</span>
                     </label>
                     <label className="quiz-option flex items-start space-x-2">
                       <input type="radio" name="q2" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'B'} onChange={() => handleSelect('q2','B')} />
-                      <span>B) Red/Orange (≈ pH 2)</span>
+                      <span>B) pH will increase</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q2" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'C'} onChange={() => handleSelect('q2','C')} />
+                      <span>C) pH will decrease</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q2" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q2 === 'D'} onChange={() => handleSelect('q2','D')} />
+                      <span>D) pH will become 7</span>
                     </label>
                   </div>
                   {quizSubmitted && (() => {
-                    const correct = 'A';
+                    const correct = 'C';
                     const selected = quizSelections.q2;
                     const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
                     return (
                       <>
-                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) Yellow/Orange (≈ pH 3–4)' : selected === 'B' ? 'B) Red/Orange (≈ pH 2)' : ''}</div>
-                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: A) Yellow/Orange (≈ pH 3–4)</div>
+                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) pH will remain unchanged' : selected === 'B' ? 'B) pH will increase' : selected === 'C' ? 'C) pH will decrease' : selected === 'D' ? 'D) pH will become 7' : ''}</div>
+                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: C) pH will decrease</div>
                       </>
                     );
                   })()}
                 </section>
 
                 <section className="quiz-item">
-                  <h3 className="font-semibold">Q3. Measured pH for 0.01 M HCl + Indicator in this experiment is approximately:</h3>
+                  <h3 className="font-semibold">Q3. Two acids of the same concentration (0.01 M) give different pH values. This shows that:</h3>
                   <div className="mt-2 space-y-2">
                     <label className="quiz-option flex items-start space-x-2">
                       <input type="radio" name="q3" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'A'} onChange={() => handleSelect('q3','A')} />
-                      <span>A) ≈ 2</span>
+                      <span>A) Concentration of acid alone decides pH</span>
                     </label>
                     <label className="quiz-option flex items-start space-x-2">
                       <input type="radio" name="q3" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'B'} onChange={() => handleSelect('q3','B')} />
-                      <span>B) ≈ 4</span>
+                      <span>B) Strength of acid (Ka) also affects pH</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q3" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'C'} onChange={() => handleSelect('q3','C')} />
+                      <span>C) Universal indicator is not reliable</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q3" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q3 === 'D'} onChange={() => handleSelect('q3','D')} />
+                      <span>D) Weak acids have no H⁺ ions</span>
                     </label>
                   </div>
                   {quizSubmitted && (() => {
-                    const correct = 'A';
+                    const correct = 'B';
                     const selected = quizSelections.q3;
                     const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
                     return (
                       <>
-                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) ≈ 2' : selected === 'B' ? 'B) ≈ 4' : ''}</div>
-                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: A) ≈ 2</div>
+                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) Concentration of acid alone decides pH' : selected === 'B' ? 'B) Strength of acid (Ka) also affects pH' : selected === 'C' ? 'C) Universal indicator is not reliable' : selected === 'D' ? 'D) Weak acids have no H⁺ ions' : ''}</div>
+                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: B) Strength of acid (Ka) also affects pH</div>
                       </>
                     );
                   })()}
                 </section>
+
+                <section className="quiz-item">
+                  <h3 className="font-semibold">Q4. Which of the following correctly represents the relationship between Ka, acid strength, and pH?</h3>
+                  <div className="mt-2 space-y-2">
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q4" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'A'} onChange={() => handleSelect('q4','A')} />
+                      <span>A) Higher Ka → stronger acid → lower pH</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q4" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'B'} onChange={() => handleSelect('q4','B')} />
+                      <span>B) Higher Ka → weaker acid → higher pH</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q4" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'C'} onChange={() => handleSelect('q4','C')} />
+                      <span>C) Lower Ka → stronger acid → lower pH</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q4" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q4 === 'D'} onChange={() => handleSelect('q4','D')} />
+                      <span>D) Ka value does not affect pH</span>
+                    </label>
+                  </div>
+                  {quizSubmitted && (() => {
+                    const correct = 'A';
+                    const selected = quizSelections.q4;
+                    const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                    return (
+                      <>
+                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) Higher Ka → stronger acid → lower pH' : selected === 'B' ? 'B) Higher Ka → weaker acid → higher pH' : selected === 'C' ? 'C) Lower Ka → stronger acid → lower pH' : selected === 'D' ? 'D) Ka value does not affect pH' : ''}</div>
+                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: A) Higher Ka → stronger acid → lower pH</div>
+                      </>
+                    );
+                  })()}
+                </section>
+
+                <section className="quiz-item">
+                  <h3 className="font-semibold">Q5. Why does universal indicator give different colours for HCl and CH₃COOH, even at the same molar concentration?</h3>
+                  <div className="mt-2 space-y-2">
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q5" value="A" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'A'} onChange={() => handleSelect('q5','A')} />
+                      <span>A) It depends only on colour of solution, not acidity</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q5" value="B" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'B'} onChange={() => handleSelect('q5','B')} />
+                      <span>B) Strong and weak acids produce different [H⁺] at same concentration</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q5" value="C" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'C'} onChange={() => handleSelect('q5','C')} />
+                      <span>C) Universal indicator reacts differently with different acids</span>
+                    </label>
+                    <label className="quiz-option flex items-start space-x-2">
+                      <input type="radio" name="q5" value="D" className="mt-1" disabled={quizSubmitted} checked={quizSelections.q5 === 'D'} onChange={() => handleSelect('q5','D')} />
+                      <span>D) HCl absorbs light while CH₃COOH does not</span>
+                    </label>
+                  </div>
+                  {quizSubmitted && (() => {
+                    const correct = 'B';
+                    const selected = quizSelections.q5;
+                    const yourClass = selected === correct ? 'mt-2 text-sm text-green-700 font-medium' : 'mt-2 text-sm text-red-600 font-medium';
+                    return (
+                      <>
+                        <div className={yourClass}>Your answer: {selected === 'A' ? 'A) It depends only on colour of solution, not acidity' : selected === 'B' ? 'B) Strong and weak acids produce different [H⁺] at same concentration' : selected === 'C' ? 'C) Universal indicator reacts differently with different acids' : selected === 'D' ? 'D) HCl absorbs light while CH₃COOH does not' : ''}</div>
+                        <div className="mt-2 text-sm text-green-700 font-medium">Answer: B) Strong and weak acids produce different [H⁺] at same concentration</div>
+                      </>
+                    );
+                  })()}
+                </section>
+
               </div>
             </CardContent>
 

--- a/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -5,7 +5,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { WorkBench } from "@/experiments/EquilibriumShift/components/WorkBench";
 import { Equipment, PH_LAB_EQUIPMENT } from "./Equipment";
 import { COLORS, INITIAL_TESTTUBE, GUIDED_STEPS, ANIMATION } from "../constants";
-import { Beaker, Info, Wrench, CheckCircle, ArrowRight, TestTube, Undo2, TrendingUp, Clock, FlaskConical, Home } from "lucide-react";
+import { Beaker, Info, Wrench, CheckCircle, ArrowRight, ArrowLeft, TestTube, Undo2, TrendingUp, Clock, FlaskConical, Home } from "lucide-react";
 import { Link } from "wouter";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 

--- a/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -1067,11 +1067,14 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
               <div>
                 {!quizSubmitted ? (
                   <>
-                    <Button variant="outline" onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); setShowQuizModal(false); }}>Cancel</Button>
+                    <Button variant="outline" onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); }}>Reset</Button>
                     <Button onClick={() => { submitQuiz(); }}>Submit</Button>
                   </>
                 ) : (
-                  <Button onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); setShowQuizModal(false); }}>Close</Button>
+                  <>
+                    <Button variant="outline" onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); }}>Reset</Button>
+                    <Button onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); setShowQuizModal(false); }}>Close</Button>
+                  </>
                 )}
               </div>
             </div>

--- a/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/PHComparison/components/VirtualLab.tsx
@@ -1052,15 +1052,28 @@ export default function VirtualLab({ experimentStarted, onStartExperiment, isRun
               </div>
             </CardContent>
 
-            <div className="p-4 flex justify-end space-x-2">
-              {!quizSubmitted ? (
-                <>
-                  <Button variant="outline" onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); setShowQuizModal(false); }}>Cancel</Button>
-                  <Button onClick={() => { submitQuiz(); }}>Submit</Button>
-                </>
-              ) : (
-                <Button onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); setShowQuizModal(false); }}>Close</Button>
-              )}
+            <div className="p-4 flex justify-between items-center">
+              <div className="flex items-center space-x-2">
+                <Button variant="outline" className="flex items-center" onClick={() => { setShowQuizModal(false); setShowResultsModal(true); }}>
+                  <ArrowLeft className="w-4 h-4 mr-2" /> Back to Experiment
+                </Button>
+                <Link href="/">
+                  <Button variant="outline" className="flex items-center">
+                    <ArrowLeft className="w-4 h-4 mr-2 rotate-180" /> Return to Experiments
+                  </Button>
+                </Link>
+              </div>
+
+              <div>
+                {!quizSubmitted ? (
+                  <>
+                    <Button variant="outline" onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); setShowQuizModal(false); }}>Cancel</Button>
+                    <Button onClick={() => { submitQuiz(); }}>Submit</Button>
+                  </>
+                ) : (
+                  <Button onClick={() => { setQuizSelections({}); setQuizSubmitted(false); setQuizScore(null); setShowQuizModal(false); }}>Close</Button>
+                )}
+              </div>
             </div>
           </Card>
         </DialogContent>


### PR DESCRIPTION
## Purpose
The user requested to add a quiz feature to the ammonium buffer experiment (NH4OH/NH4Cl) similar to other experiments. The quiz should be accessible from the results and analysis page and include specific questions about buffer systems, Henderson-Hasselbalch equation, and pH changes. The quiz should have proper validation, scoring, and reset functionality.

## Code changes
- Added quiz modal state management with `showQuizModal`, `quizSelections`, `quizSubmitted`, and `quizScore` states
- Implemented quiz functionality with 5 multiple-choice questions about NH4OH/NH4Cl buffer system
- Added quiz validation requiring all questions to be answered before submission
- Implemented scoring system with correct answer checking and visual feedback
- Added "QUIZ" button to the results modal that opens the quiz interface
- Created quiz modal with proper navigation buttons (Back to Experiment, Return to Experiments)
- Added reset functionality to clear quiz selections and allow retaking
- Implemented answer key display after submission showing correct/incorrect answers
- Added proper styling and layout for quiz questions and options

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 84`

🔗 [Edit in Builder.io](https://builder.io/app/projects/13894a4be40b45ceb838a554a024c1bc/pixel-verse)

👀 [Preview Link](https://13894a4be40b45ceb838a554a024c1bc-pixel-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>13894a4be40b45ceb838a554a024c1bc</projectId>-->
<!--<branchName>pixel-verse</branchName>-->