### PR TITLE
Replace volumetric flask icon in step 4 workspace

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -307,7 +307,19 @@ export const Equipment: React.FC<EquipmentProps> = ({
         const isNearMark = preparationState?.nearMark;
         return (
           <div className="text-center relative">
-            <FlaskConical className="w-8 h-8 mx-auto mb-2 text-blue-600" />
+            {imageSrc ? (
+              <TransparentImage
+                src={imageSrc}
+                alt={name}
+                className={position ? "mx-auto mb-2 h-40 w-auto object-contain mix-blend-multiply pointer-events-none select-none" : "mx-auto mb-2 h-24 w-auto object-contain mix-blend-multiply pointer-events-none select-none"}
+                tolerance={245}
+                colorDiff={8}
+                draggable={false}
+                onDragStart={(e) => e.preventDefault()}
+              />
+            ) : (
+              <FlaskConical className="w-8 h-8 mx-auto mb-2 text-blue-600" />
+            )}
             <div className="text-xs space-y-1">
               <div>250 mL</div>
               {chemicals.length > 0 && (
@@ -547,7 +559,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             name.toLowerCase().includes('volumetric-flask') ||
             name.toLowerCase().includes('flask')
           ) {
-            payload.imageSrc = "https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2Fc62483aee73448e6934446dfd24d2875?format=webp&width=800";
+            payload.imageSrc = undefined as any;
           }
 
           e.dataTransfer.setData("text/plain", JSON.stringify(payload));

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -547,7 +547,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
             name.toLowerCase().includes('volumetric-flask') ||
             name.toLowerCase().includes('flask')
           ) {
-            payload.imageSrc = "https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2Fccda75b4063b4fe985feac502d383c08?format=webp&width=800";
+            payload.imageSrc = "https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2Fc62483aee73448e6934446dfd24d2875?format=webp&width=800";
           }
 
           e.dataTransfer.setData("text/plain", JSON.stringify(payload));

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -252,7 +252,9 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
           chemicals: [],
           typeId: data.id,
           name: data.name,
-          imageSrc: data.imageSrc,
+          imageSrc: (step.id === 4 && (data.id === 'volumetric_flask' || (data.name || '').toLowerCase().includes('volumetric flask')))
+            ? 'https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2F1782add6aa7c40cc992b82016876895e?format=webp&width=800'
+            : data.imageSrc,
         }
       ]);
       // Notify parent that this equipment was placed so it can be removed from the palette
@@ -300,7 +302,9 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
           chemicals: [],
           typeId: eq.id,
           name: eq.name,
-          imageSrc: undefined,
+          imageSrc: (step.id === 4 && eq.id === 'volumetric_flask')
+            ? 'https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2F1782add6aa7c40cc992b82016876895e?format=webp&width=800'
+            : undefined,
         }
       ]);
       // Notify parent that this equipment was placed (hide from palette)


### PR DESCRIPTION
## Purpose

The user requested to replace the volumetric flask icon with a specific image when it is dragged and dropped into the workspace during step 4 of the experiment. This change improves the visual representation of the volumetric flask equipment in the chemistry lab simulation.

## Code changes

- **Equipment.tsx**: Modified the volumetric flask rendering to conditionally display a custom image using `TransparentImage` component instead of the default `FlaskConical` icon when `imageSrc` is provided
- **WorkBench.tsx**: Added conditional logic to set a specific image URL for volumetric flask equipment when dropped in step 4, while maintaining the default behavior for other steps
- Updated drag and drop handling to properly assign the custom image source based on step context and equipment type

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 93`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0441334b7e0b4532bc5826686a623153/echo-haven)

👀 [Preview Link](https://0441334b7e0b4532bc5826686a623153-echo-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0441334b7e0b4532bc5826686a623153</projectId>-->
<!--<branchName>echo-haven</branchName>-->