### PR TITLE
Remove wash bottle after beaker rinse in step 4

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -441,10 +441,16 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
         setWashAnimation({ x: animX, y: animY, active: true });
         showMessage('Rinsing the beaker...');
 
-        // After animation completes, clear chemicals in the beaker visually
+        // After animation completes, clear chemicals in the beaker visually and remove the wash bottle for step 4
         window.setTimeout(() => {
           setEquipmentPositions(prev => prev.map(pos => pos.id === nearest.id ? { ...pos, chemicals: [] } : pos));
           setWashAnimation(null);
+          try {
+            if (step.id === 4) {
+              // remove the wash bottle used for rinsing from the workbench
+              setEquipmentPositions(prev => prev.filter(pos => pos.id !== bottle.id));
+            }
+          } catch (e) {}
           showMessage('Beaker rinsed.');
         }, 2200);
 


### PR DESCRIPTION
## Purpose
The user requested to remove the wash bottle from the workspace after rinsing the beaker in step 4 of the Oxalic Acid Standard Solution preparation experiment to improve the lab simulation workflow.

## Code changes
- Added conditional logic to remove the wash bottle from the workbench after the beaker rinse animation completes in step 4
- Wrapped the removal logic in a try-catch block for error handling
- Updated the comment to reflect the new functionality of removing the wash bottle in addition to clearing chemicals

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 105`

🔗 [Edit in Builder.io](https://builder.io/app/projects/950f009f61744fa5a8b02f65320e7fb2/echo-oasis)

👀 [Preview Link](https://950f009f61744fa5a8b02f65320e7fb2-echo-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>950f009f61744fa5a8b02f65320e7fb2</projectId>-->
<!--<branchName>echo-oasis</branchName>-->