### PR TITLE
Fix oxalic acid experiment step 4-5 transition and beaker display

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -389,7 +389,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
 
         return (
           <div className="text-center relative">
-            {imageSrc && stepId === 4 ? (
+            {showCustomBeakerImage ? (
               <TransparentImage
                 src={imageSrc}
                 alt={name}

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -385,7 +385,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
       case "beaker":
         const hasOxalicAcid = chemicals.some(c => c.id === "oxalic_acid");
         const hasWater = chemicals.some(c => c.id === "distilled_water");
-        const showCustomBeakerImage = imageSrc && stepId === 4;
+        const showCustomBeakerImage = !!imageSrc && (stepId === 4 || !!position);
 
         return (
           <div className="text-center relative">

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
@@ -277,7 +277,7 @@ function OxalicAcidVirtualLab({
     }, 1000);
   }, [measurements.massWeighed, addResult]);
 
-  const handleStepAction = useCallback(() => {
+  const handleStepAction = useCallback((opts?: { skipAnimation?: boolean }) => {
     switch (step.id) {
       case 1:
         handleCalculation();
@@ -289,7 +289,12 @@ function OxalicAcidVirtualLab({
         handleDissolving();
         break;
       case 4:
-        handleTransfer();
+        if (opts && opts.skipAnimation) {
+          // directly mark transfer complete without showing transfer animation
+          handleTransferComplete();
+        } else {
+          handleTransfer();
+        }
         break;
       case 5:
         handleNearMark();
@@ -301,7 +306,7 @@ function OxalicAcidVirtualLab({
         handleFinalMixing();
         break;
     }
-  }, [step.id, handleCalculation, handleWeighing, handleDissolving, handleTransfer, handleNearMark, handleFinalVolume, handleFinalMixing]);
+  }, [step.id, handleCalculation, handleWeighing, handleDissolving, handleTransfer, handleTransferComplete, handleNearMark, handleFinalVolume, handleFinalMixing]);
 
   useEffect(() => {
     if (step.id !== 1) {

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -449,6 +449,8 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
             if (step.id === 4) {
               // remove the wash bottle used for rinsing from the workbench
               setEquipmentPositions(prev => prev.filter(pos => pos.id !== bottle.id));
+              // automatically trigger the step action for step 4 (transfer to flask)
+              try { if (typeof onStepAction === 'function') onStepAction(); } catch (e) {}
             }
           } catch (e) {}
           showMessage('Beaker rinsed.');

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -25,7 +25,7 @@ interface WorkBenchProps {
   stepNumber: number;
   totalSteps: number;
   experimentTitle: string;
-  onStepAction: () => void;
+  onStepAction: (opts?: { skipAnimation?: boolean }) => void;
   canProceed: boolean;
   equipmentPositions: EquipmentPosition[];
   setEquipmentPositions: React.Dispatch<React.SetStateAction<EquipmentPosition[]>>;

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -450,7 +450,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
               // remove the wash bottle used for rinsing from the workbench
               setEquipmentPositions(prev => prev.filter(pos => pos.id !== bottle.id));
               // automatically trigger the step action for step 4 (transfer to flask)
-              try { if (typeof onStepAction === 'function') onStepAction(); } catch (e) {}
+              try { if (typeof onStepAction === 'function') onStepAction({ skipAnimation: true }); } catch (e) {}
             }
           } catch (e) {}
           showMessage('Beaker rinsed.');


### PR DESCRIPTION
## Purpose

The user requested improvements to the Oxalic Acid Standardization experiment workflow:
- Automatically advance from step 4 to step 5 after rinsing is complete and wash bottle is removed
- Remove the transfer animation when automatically transitioning to step 5
- Fix the beaker image disappearing issue in step 5

## Code changes

**Equipment.tsx:**
- Modified beaker display logic to show custom beaker image in step 5 when position is set
- Updated `showCustomBeakerImage` condition to include `stepId === 4 || !!position`

**VirtualLab.tsx:**
- Added optional `skipAnimation` parameter to `handleStepAction` function
- Modified step 4 handling to skip transfer animation when `skipAnimation` is true
- Updated function dependencies to include `handleTransferComplete`

**WorkBench.tsx:**
- Updated `onStepAction` prop type to accept optional parameters
- Added automatic step progression after wash bottle removal in step 4
- Calls `onStepAction({ skipAnimation: true })` to advance without animation

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 109`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fb6362cb68ac41f2b86c0361bb068f6a/zen-realm)

👀 [Preview Link](https://fb6362cb68ac41f2b86c0361bb068f6a-zen-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fb6362cb68ac41f2b86c0361bb068f6a</projectId>-->
<!--<branchName>zen-realm</branchName>-->