### PR TITLE
Fix stirring animation and beaker sizing in step 6-7

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -423,19 +423,25 @@ export const Equipment: React.FC<EquipmentProps> = ({
       case "beaker":
         const hasOxalicAcid = chemicals.some(c => c.id === "oxalic_acid");
         const hasWater = chemicals.some(c => c.id === "distilled_water");
-        const showCustomBeakerImage = !!imageSrc && (stepId === 4 || stepId === 6 || !!position);
+        const showCustomBeakerImage = !!imageSrc && (stepId === 4 || stepId === 6 || stepId === 7 || !!position);
 
         return (
           <div className="text-center relative">
             {showCustomBeakerImage ? (
               (() => {
                 const hasWaterNow = chemicals.some(c => (c.id || '').toString().toLowerCase().includes('distilled'));
-                const heightClass = position ? (stepId === 6 ? "h-56 md:h-72" : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? "h-80 md:h-96" : "h-40")) : "h-24";
+                // Increase size for step 7 after mixing; keep step 6 moderately large during mixing
+                const heightClass = position
+                  ? (stepId === 7 ? "h-96 md:h-112" : (stepId === 6 ? "h-56 md:h-72" : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? "h-80 md:h-96" : "h-40")))
+                  : (stepId === 7 ? "h-56" : "h-24");
+
+                const scaleClass = stepId === 7 ? 'scale-115 md:scale-125' : (stepId === 6 ? 'scale-105 md:scale-110' : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? 'scale-110 md:scale-125' : ''));
+
                 return (
                   <TransparentImage
                     src={imageSrc}
                     alt={name}
-                    className={`mx-auto mb-2 ${heightClass} w-auto object-contain mix-blend-multiply pointer-events-none select-none transition-transform duration-500 ${stepId === 6 ? 'scale-105 md:scale-110' : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? 'scale-110 md:scale-125' : '')}`}
+                    className={`mx-auto mb-2 ${heightClass} w-auto object-contain mix-blend-multiply pointer-events-none select-none transition-transform duration-500 ${scaleClass}`}
                     tolerance={245}
                     colorDiff={8}
                     draggable={false}

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -342,7 +342,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
                   }}
                 />
               )}
-              {isAtMark && (
+              {isAtMark && stepId !== 7 && (
                 <div className="text-green-600 font-bold">At Mark!</div>
               )}
             </div>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -430,12 +430,12 @@ export const Equipment: React.FC<EquipmentProps> = ({
             {showCustomBeakerImage ? (
               (() => {
                 const hasWaterNow = chemicals.some(c => (c.id || '').toString().toLowerCase().includes('distilled'));
-                // Increase size for step 7 after mixing; keep step 6 moderately large during mixing
+                // Use reasonable sizes for step 7 (smaller than before) and keep step 6 moderately large during mixing
                 const heightClass = position
-                  ? (stepId === 7 ? "h-64 md:h-80" : (stepId === 6 ? "h-56 md:h-72" : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? "h-80 md:h-96" : "h-40")))
-                  : (stepId === 7 ? "h-40" : "h-24");
+                  ? (stepId === 7 ? "h-48 md:h-56" : (stepId === 6 ? "h-56 md:h-72" : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? "h-80 md:h-96" : "h-40")))
+                  : (stepId === 7 ? "h-32" : "h-24");
 
-                const scaleClass = stepId === 7 ? 'scale-105 md:scale-110' : (stepId === 6 ? 'scale-105 md:scale-110' : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? 'scale-110 md:scale-125' : ''));
+                const scaleClass = stepId === 7 ? 'scale-100 md:scale-105' : (stepId === 6 ? 'scale-105 md:scale-110' : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? 'scale-110 md:scale-125' : ''));
 
                 return (
                   <TransparentImage

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -432,10 +432,10 @@ export const Equipment: React.FC<EquipmentProps> = ({
                 const hasWaterNow = chemicals.some(c => (c.id || '').toString().toLowerCase().includes('distilled'));
                 // Increase size for step 7 after mixing; keep step 6 moderately large during mixing
                 const heightClass = position
-                  ? (stepId === 7 ? "h-96 md:h-112" : (stepId === 6 ? "h-56 md:h-72" : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? "h-80 md:h-96" : "h-40")))
-                  : (stepId === 7 ? "h-56" : "h-24");
+                  ? (stepId === 7 ? "h-64 md:h-80" : (stepId === 6 ? "h-56 md:h-72" : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? "h-80 md:h-96" : "h-40")))
+                  : (stepId === 7 ? "h-40" : "h-24");
 
-                const scaleClass = stepId === 7 ? 'scale-115 md:scale-125' : (stepId === 6 ? 'scale-105 md:scale-110' : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? 'scale-110 md:scale-125' : ''));
+                const scaleClass = stepId === 7 ? 'scale-105 md:scale-110' : (stepId === 6 ? 'scale-105 md:scale-110' : (stepId === 5 && (hasWaterNow || enlargeAfterAnimation) ? 'scale-110 md:scale-125' : ''));
 
                 return (
                   <TransparentImage

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -367,6 +367,34 @@ export const Equipment: React.FC<EquipmentProps> = ({
           </div>
         );
 
+      case "stirrer":
+        return (
+          <div className="relative flex flex-col items-center">
+            {imageSrc ? (
+              <TransparentImage
+                src={imageSrc}
+                alt={name}
+                className={position ? "h-40 w-auto object-contain pointer-events-none select-none" : "h-24 w-auto object-contain pointer-events-none select-none"}
+                tolerance={245}
+                colorDiff={8}
+                draggable={false}
+                onDragStart={(e) => e.preventDefault()}
+              />
+            ) : (
+              icon
+            )}
+            <div className="mt-2">
+              <button
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={(e) => { e.stopPropagation(); onAction?.("stir", id); }}
+                className="text-xs bg-green-500 text-white px-2 py-1 rounded hover:bg-green-600"
+              >
+                Use Stirrer
+              </button>
+            </div>
+          </div>
+        );
+
       case "oxalic_acid":
         return (
           <div className="relative flex justify-center">

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/StirringAnimation.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/StirringAnimation.tsx
@@ -134,7 +134,7 @@ export const StirringAnimation: React.FC<StirringAnimationProps> = ({
 
       {/* Vortex effect */}
       <motion.div
-        className="absolute rounded-full border-2 border-blue-300 opacity-50"
+        className="absolute rounded-full border-2 border-gray-300 opacity-20"
         style={{
           width: 40,
           height: 40,
@@ -142,8 +142,8 @@ export const StirringAnimation: React.FC<StirringAnimationProps> = ({
           top: centerY - 20,
         }}
         animate={{
-          scale: [1, 1.2, 1],
-          opacity: [0.3, 0.1, 0.3],
+          scale: [1, 1.08, 1],
+          opacity: [0.25, 0.08, 0.25],
         }}
         transition={{
           duration: speedConfig[stirringSpeed].duration,

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/StirringAnimation.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/StirringAnimation.tsx
@@ -89,19 +89,6 @@ export const StirringAnimation: React.FC<StirringAnimationProps> = ({
       style={{ width: containerWidth, height: containerHeight }}
     >
       {/* Solution background with swirl effect */}
-      <motion.div
-        className="absolute inset-0 rounded-lg"
-        style={{
-          background: `conic-gradient(from ${stirringAngle}deg, ${solutionColor}80, transparent, ${solutionColor}80)`,
-        }}
-        animate={{
-          rotate: stirringAngle,
-        }}
-        transition={{
-          duration: 0,
-          ease: "linear",
-        }}
-      />
 
       {/* Particle system */}
       {particles.map((particle) => (

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/StirringAnimation.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/StirringAnimation.tsx
@@ -114,16 +114,16 @@ export const StirringAnimation: React.FC<StirringAnimationProps> = ({
 
       {/* Glass rod */}
       <motion.div
-        className="absolute bg-gray-300 rounded-full"
+        className="absolute bg-gray-400 rounded-full"
         style={{
-          width: 3,
-          height: containerHeight * 0.8,
-          left: centerX - 1.5,
-          top: containerHeight * 0.1,
-          transformOrigin: `1.5px ${containerHeight * 0.7}px`,
+          width: 4,
+          height: containerHeight * 0.7,
+          left: centerX - 2,
+          top: containerHeight * 0.15,
+          transformOrigin: `2px ${containerHeight * 0.65}px`,
         }}
         animate={{
-          rotate: [0, 10, -10, 0],
+          rotate: [0, 12, -12, 0],
         }}
         transition={{
           duration: speedConfig[stirringSpeed].duration,

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Equipment } from "./Equipment";
 import { Chemical } from "./Chemical";
 import { Play, Pause, RotateCcw, Calculator, FlaskConical } from "lucide-react";
+import StirringAnimation from "./StirringAnimation";
 import type {
   EquipmentPosition,
   SolutionPreparationState,

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -527,10 +527,12 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
             if (beakerEl) {
               const surfaceRect = surfaceEl.getBoundingClientRect();
               const beakerRect = beakerEl.getBoundingClientRect();
-              animX = beakerRect.left - surfaceRect.left + beakerRect.width * 0.5 - 40; // center - half width
-              animY = beakerRect.top - surfaceRect.top - Math.max(48, beakerRect.height * 0.6);
               animW = Math.max(64, Math.floor(beakerRect.width * 0.9));
               animH = Math.max(56, Math.floor(beakerRect.height * 0.9));
+              // Position the overlay so it is exactly centered above the beaker
+              animX = beakerRect.left - surfaceRect.left + (beakerRect.width - animW) / 2;
+              // place the overlay just above the beaker with a small margin
+              animY = beakerRect.top - surfaceRect.top - animH - 8;
             }
           }
 

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -75,6 +75,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
   // pouring animation state when adding acid into the weighing boat
   const [pouring, setPouring] = useState<{ boatId: string; x: number; y: number; active: boolean } | null>(null);
   const [washAnimation, setWashAnimation] = useState<{ x: number; y: number; active: boolean } | null>(null);
+  const [mixingAnimation, setMixingAnimation] = useState<{ x: number; y: number; width?: number; height?: number; active: boolean } | null>(null);
   const pourTimeoutRef = useRef<number | null>(null);
 
   // messages shown on the workbench area (transient)

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -527,12 +527,15 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
             if (beakerEl) {
               const surfaceRect = surfaceEl.getBoundingClientRect();
               const beakerRect = beakerEl.getBoundingClientRect();
-              animW = Math.max(64, Math.floor(beakerRect.width * 0.9));
-              animH = Math.max(56, Math.floor(beakerRect.height * 0.9));
-              // Position the overlay so it is exactly centered above the beaker
+              // Make overlay cover the upper interior of the beaker so the stirrer appears inside it
+              animW = Math.max(48, Math.floor(beakerRect.width * 0.6));
+              animH = Math.max(48, Math.floor(beakerRect.height * 0.6));
+
+              // Center horizontally inside the beaker
               animX = beakerRect.left - surfaceRect.left + (beakerRect.width - animW) / 2;
-              // place the overlay just above the beaker with a small margin
-              animY = beakerRect.top - surfaceRect.top - animH - 8;
+
+              // Position vertically so the overlay sits inside the beaker (a bit below the rim)
+              animY = beakerRect.top - surfaceRect.top + Math.max(8, Math.floor(beakerRect.height * 0.15));
             }
           }
 

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -516,23 +516,27 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
             return;
           }
 
-          // Compute approximate animation start position using DOM if available
+          // Compute approximate animation position centered above the beaker using DOM when available
           const surfaceEl = (document.querySelector('[data-oxalic-workbench-surface="true"]') as HTMLElement) || null;
-          let animX = (boat.x || 0) + 20;
-          let animY = (boat.y || 0) - 60;
+          let animX = (beaker.x || 0) + 20;
+          let animY = (beaker.y || 0) - 60;
+          let animW = 80;
+          let animH = 100;
           if (surfaceEl) {
-            const boatEl = surfaceEl.querySelector(`[data-equipment-id="${boat.id}"]`) as HTMLElement | null;
-            if (boatEl) {
+            const beakerEl = surfaceEl.querySelector(`[data-equipment-id="${beaker.id}"]`) as HTMLElement | null;
+            if (beakerEl) {
               const surfaceRect = surfaceEl.getBoundingClientRect();
-              const boatRect = boatEl.getBoundingClientRect();
-              animX = boatRect.left - surfaceRect.left + boatRect.width * 0.5;
-              animY = boatRect.top - surfaceRect.top - Math.max(40, boatRect.height * 0.6);
+              const beakerRect = beakerEl.getBoundingClientRect();
+              animX = beakerRect.left - surfaceRect.left + beakerRect.width * 0.5 - 40; // center - half width
+              animY = beakerRect.top - surfaceRect.top - Math.max(48, beakerRect.height * 0.6);
+              animW = Math.max(64, Math.floor(beakerRect.width * 0.9));
+              animH = Math.max(56, Math.floor(beakerRect.height * 0.9));
             }
           }
 
-          // Start a visual wash-like animation from the boat towards the beaker
-          setWashAnimation({ x: animX, y: animY, active: true });
-          showMessage('Mixing acid into the beaker...');
+          // Start a stirring animation overlay positioned above the beaker
+          setMixingAnimation({ x: animX, y: animY, width: animW, height: animH, active: true });
+          showMessage('Stirring the beaker to mix the acid...');
 
           // Duration of mixing animation (7000ms as requested)
           const MIX_DURATION = 7000;

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -1106,6 +1106,24 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
               </div>
             )}
 
+            {mixingAnimation && mixingAnimation.active && (
+              <div
+                aria-hidden
+                className="mixing-animation-wrapper"
+                style={{ left: mixingAnimation.x, top: mixingAnimation.y, position: 'absolute', zIndex: 80 }}
+              >
+                <div style={{ width: mixingAnimation.width || 80, height: mixingAnimation.height || 100 }}>
+                  <StirringAnimation
+                    isActive={true}
+                    containerWidth={mixingAnimation.width || 80}
+                    containerHeight={mixingAnimation.height || 100}
+                    stirringSpeed="medium"
+                    solutionColor="#87ceeb"
+                  />
+                </div>
+              </div>
+            )}
+
             {washAnimation && washAnimation.active && (
               <div
                 aria-hidden
@@ -1395,7 +1413,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                 </div>
               </div>
               <div className="text-xs text-gray-600 space-y-1">
-                <p><strong>Formula:</strong> m = M × V × MW</p>
+                <p><strong>Formula:</strong> m = M × V �� MW</p>
                 <p><strong>Calculation:</strong> {(0.05 * 0.25 * 126.07).toFixed(4)} g = 0.05 M × 0.250 L �� 126.07 g/mol</p>
               </div>
             </CardContent>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -572,8 +572,8 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                 return next;
               });
 
-              // stop animation overlay
-              setWashAnimation(null);
+              // stop mixing animation overlay
+              setMixingAnimation(null);
 
               // Inform user and complete the step action (which will update preparation state in VirtualLab)
               showMessage('Mixing complete. Final beaker image updated.');

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -550,14 +550,14 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                 // replace beaker image and filter out stirrer and weighing boats
                 const next = prev
                   .map(pos => {
-                    const key = (pos.typeId ?? pos.id || '').toString().toLowerCase();
+                    const key = ((pos.typeId ?? pos.id) || '').toString().toLowerCase();
                     if (key.includes('beaker')) {
                       return { ...pos, imageSrc: mixedBeakerImage };
                     }
                     return pos;
                   })
                   .filter(pos => {
-                    const key = (pos.typeId ?? pos.id || '').toString().toLowerCase();
+                    const key = ((pos.typeId ?? pos.id) || '').toString().toLowerCase();
                     // remove any weighing boat or stirrer positions from the workspace
                     if (key.includes('weighing_boat') || key.includes('weighing-boat') || key.includes('stirrer')) return false;
                     return true;


### PR DESCRIPTION
## Purpose

Users reported multiple issues with the stirring animation and beaker display in the Oxalic Acid Standardization experiment:
- Stirrer needed to appear inside the beaker during mixing rather than above it
- Blue color effect around stirrer needed removal for cleaner animation
- Beaker size inconsistencies in step 7 after stirring animation
- Unwanted "At Mark" label appearing in volumetric flask in step 7

## Code changes

### Equipment.tsx
- **Stirrer positioning**: Added new stirrer case with proper positioning logic to place stirrer inside beaker
- **Beaker sizing**: Implemented step-specific size controls for step 7 (h-48 md:h-56) to maintain reasonable size
- **Label removal**: Added condition `stepId !== 7` to hide "At Mark" label in step 7

### StirringAnimation.tsx
- **Visual cleanup**: Removed blue conic-gradient background effect that was creating unwanted color around stirrer
- **Animation refinement**: Adjusted stirrer appearance (gray-400 color, better positioning within container)
- **Vortex effect**: Reduced opacity and scale of vortex effect for subtler animation

### WorkBench.tsx
- **Mixing animation**: Added comprehensive stirring logic for step 6 with proper beaker detection and positioning
- **Animation overlay**: Implemented mixing animation that positions stirrer inside beaker bounds
- **State management**: Added mixingAnimation state to control 7-second stirring sequence
- **Cleanup**: Automatic removal of stirrer and weighing boat after mixing completion

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 118`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fb6362cb68ac41f2b86c0361bb068f6a/quantum-sanctuary)

👀 [Preview Link](https://fb6362cb68ac41f2b86c0361bb068f6a-quantum-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fb6362cb68ac41f2b86c0361bb068f6a</projectId>-->
<!--<branchName>quantum-sanctuary</branchName>-->