### PR TITLE
Enlarge volumetric flask image after step 7 animation

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/Equipment.tsx
@@ -114,6 +114,18 @@ export const Equipment: React.FC<EquipmentProps> = ({
   useEffect(() => {
     if (stepId !== 5) setEnlargeAfterAnimation(false);
   }, [stepId]);
+
+  // Enlarge volumetric flask image after the final pour animation completes (step 7)
+  const [enlargeFlaskAfterPour, setEnlargeFlaskAfterPour] = useState(false);
+  useEffect(() => {
+    if (equipmentIdentifier !== "volumetric_flask") return;
+    const handler = () => setEnlargeFlaskAfterPour(true);
+    window.addEventListener('oxalic_flask_image_shown', handler as EventListener);
+    return () => window.removeEventListener('oxalic_flask_image_shown', handler as EventListener);
+  }, [equipmentIdentifier]);
+  useEffect(() => {
+    if (stepId !== 7) setEnlargeFlaskAfterPour(false);
+  }, [stepId]);
   const isAnalytical = equipmentIdentifier === "analytical_balance";
   const isWeighingBoat = equipmentIdentifier === "weighing_boat";
 
@@ -321,7 +333,7 @@ export const Equipment: React.FC<EquipmentProps> = ({
               <TransparentImage
                 src={imageSrc}
                 alt={name}
-                className={position ? "mx-auto mb-2 h-40 w-auto object-contain mix-blend-multiply pointer-events-none select-none" : "mx-auto mb-2 h-24 w-auto object-contain mix-blend-multiply pointer-events-none select-none"}
+                className={position ? (enlargeFlaskAfterPour ? "mx-auto mb-2 h-56 md:h-64 w-auto object-contain mix-blend-multiply pointer-events-none select-none transition-transform duration-500 scale-105" : "mx-auto mb-2 h-40 w-auto object-contain mix-blend-multiply pointer-events-none select-none") : "mx-auto mb-2 h-24 w-auto object-contain mix-blend-multiply pointer-events-none select-none"}
                 tolerance={245}
                 colorDiff={8}
                 draggable={false}

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
@@ -711,6 +711,11 @@ function OxalicAcidVirtualLab({
             return filtered;
           });
 
+          // Dispatch event so equipment instances (volumetric flask) can react and enlarge their displayed image
+          try {
+            window.dispatchEvent(new CustomEvent('oxalic_flask_image_shown', { detail: { id: flask.id } }));
+          } catch (e) {}
+
           // stop transfer animation
           setShowTransfer(false);
 


### PR DESCRIPTION
## Purpose
The user requested to make the volumetric flask image larger after the animation completes and the flask gets filled with the blue color in step 7 of the Oxalic Acid Standard Solution preparation experiment.

## Code changes
- Added state management (`enlargeFlaskAfterPour`) to track when the volumetric flask should be enlarged in step 7
- Implemented event listener for `oxalic_flask_image_shown` custom event to trigger the enlargement
- Modified the image className to conditionally apply larger dimensions (h-56 md:h-64) with smooth transition effects when the flask should be enlarged
- Added event dispatch in VirtualLab.tsx to emit the custom event when the flask image is shown after the animation completes
- Applied responsive sizing and scale transform with transition duration for smooth visual enhancement

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 121`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fb6362cb68ac41f2b86c0361bb068f6a/stellar-den)

👀 [Preview Link](https://fb6362cb68ac41f2b86c0361bb068f6a-stellar-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fb6362cb68ac41f2b86c0361bb068f6a</projectId>-->
<!--<branchName>stellar-den</branchName>-->