### PR TITLE
Replace Start with Pause button for Oxalic Acid experiment

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -71,9 +71,9 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
     }
   };
 
-  const handleStartExperiment = () => {
+  const handleStartExperiment = (run = true) => {
     setExperimentStarted(true);
-    setIsRunning(true);
+    setIsRunning(run);
     setTimer(0);
   };
 
@@ -137,7 +137,7 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
                   <span>{experiment.category}</span>
                   <span>•</span>
                   <span>{experiment.difficulty}</span>
-                  <span>•</span>
+                  <span>��</span>
                   <span>Duration: {experiment.duration} min</span>
                 </div>
                 <Progress value={progress} className="w-64" />

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
@@ -35,7 +35,7 @@ interface OxalicAcidVirtualLabProps {
   experimentTitle: string;
   allSteps: ExperimentStep[];
   experimentStarted: boolean;
-  onStartExperiment: () => void;
+  onStartExperiment: (run?: boolean) => void;
   isRunning: boolean;
   setIsRunning: (running: boolean) => void;
   onResetTimer: () => void;

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -19,7 +19,7 @@ import type {
 interface WorkBenchProps {
   step: ExperimentStep;
   experimentStarted: boolean;
-  onStartExperiment: () => void;
+  onStartExperiment: (run?: boolean) => void;
   isRunning: boolean;
   setIsRunning: (running: boolean) => void;
   onResetTimer: () => void;

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -931,10 +931,23 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
               Calculator
             </Button>
             {!experimentStarted ? (
-              <Button onClick={onStartExperiment} size="sm">
-                <Play className="w-4 h-4 mr-2" />
-                Start Experiment
-              </Button>
+              (() => {
+                const isOxalicPreparation = experimentTitle === "Preparation of Standard Solution of Oxalic Acid";
+                if (isOxalicPreparation) {
+                  return (
+                    <Button onClick={() => onStartExperiment(false)} size="sm">
+                      <Pause className="w-4 h-4 mr-2" />
+                      Pause Experiment
+                    </Button>
+                  );
+                }
+                return (
+                  <Button onClick={() => onStartExperiment(true)} size="sm">
+                    <Play className="w-4 h-4 mr-2" />
+                    Start Experiment
+                  </Button>
+                );
+              })()
             ) : (
               <div className="flex items-center space-x-2">
                 <Button


### PR DESCRIPTION
## Purpose

The user requested to modify the "Preparation of Standard Solution of Oxalic Acid" experiment by replacing the "Start Experiment" button with a "Pause Experiment" button. When clicked, this button should pause the experiment instead of starting it. This change provides better control over the experiment flow for this specific chemistry lab simulation.

## Code changes

- **Modified `handleStartExperiment` function**: Added optional `run` parameter to control whether the experiment runs or pauses
- **Updated function signatures**: Changed `onStartExperiment` type to accept optional boolean parameter across components (`OxalicAcidApp.tsx`, `VirtualLab.tsx`, `WorkBench.tsx`)
- **Implemented conditional button logic**: Added experiment title check in `WorkBench.tsx` to show "Pause Experiment" button specifically for "Preparation of Standard Solution of Oxalic Acid"
- **Updated button behavior**: Pause button calls `onStartExperiment(false)` to start experiment in paused state, while other experiments continue using `onStartExperiment(true)`
- **Icon change**: Replaced Play icon with Pause icon for the new button

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 122`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fb6362cb68ac41f2b86c0361bb068f6a/vibe-home)

👀 [Preview Link](https://fb6362cb68ac41f2b86c0361bb068f6a-vibe-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fb6362cb68ac41f2b86c0361bb068f6a</projectId>-->
<!--<branchName>vibe-home</branchName>-->