### PR TITLE
Remove step 2 and renumber oxalic acid experiment steps

### DIFF
--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -77,6 +77,17 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
     setTimer(0);
   };
 
+  // Auto-start timer when the user navigates to this experiment route
+  useEffect(() => {
+    try {
+      if (match && experimentId === experiment.id) {
+        handleStartExperiment(true);
+      }
+    } catch (e) {
+      // guard in case params are undefined; no-op
+    }
+  }, [match, experimentId]);
+
   const handleResetTimer = () => {
     setTimer(0);
     setIsRunning(false);

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -77,14 +77,11 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
     setTimer(0);
   };
 
-  // Auto-start timer when the user navigates to this experiment route
+  // Auto-start timer when this component mounts for the Oxalic Acid experiment
   useEffect(() => {
-    if (match) {
-      // mark experiment started and begin timer automatically
-      handleStartExperiment(true);
-    }
-    // only run when route match state changes
-  }, [match]);
+    handleStartExperiment(true);
+    // run only once on mount
+  }, []);
 
   const handleResetTimer = () => {
     setTimer(0);

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/OxalicAcidApp.tsx
@@ -79,14 +79,12 @@ export default function OxalicAcidApp({ onBack }: OxalicAcidAppProps) {
 
   // Auto-start timer when the user navigates to this experiment route
   useEffect(() => {
-    try {
-      if (match && experimentId === experiment.id) {
-        handleStartExperiment(true);
-      }
-    } catch (e) {
-      // guard in case params are undefined; no-op
+    if (match) {
+      // mark experiment started and begin timer automatically
+      handleStartExperiment(true);
     }
-  }, [match, experimentId]);
+    // only run when route match state changes
+  }, [match]);
 
   const handleResetTimer = () => {
     setTimer(0);

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
@@ -164,13 +164,12 @@ function OxalicAcidVirtualLab({
     try {
       // step is available from closure; ensure it's the weighing step
       if (stepNumber === 2) {
-        // mark dissolved so later steps (transfer) can proceed even if we skip explicit dissolving
+        // mark dissolved so later steps (transfer) can proceed
         setPreparationState(prev => ({ ...prev, dissolved: true }));
 
-        // small delay to allow UI updates, then advance twice to skip step 3 and go to step 4
+        // small delay to allow UI updates, then advance a single step
         setTimeout(() => {
           onStepComplete();
-          setTimeout(() => onStepComplete(), 300);
         }, 300);
       }
     } catch (e) {

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/VirtualLab.tsx
@@ -163,7 +163,7 @@ function OxalicAcidVirtualLab({
     // is set so transfer can proceed.
     try {
       // step is available from closure; ensure it's the weighing step
-      if (step.id === 2) {
+      if (stepNumber === 2) {
         // mark dissolved so later steps (transfer) can proceed even if we skip explicit dissolving
         setPreparationState(prev => ({ ...prev, dissolved: true }));
 
@@ -176,7 +176,7 @@ function OxalicAcidVirtualLab({
     } catch (e) {
       // swallow errors — fallback to single-step advance handled elsewhere
     }
-  }, [measurements.targetMass, addResult, step.id, onStepComplete]);
+  }, [measurements.targetMass, addResult, stepNumber, onStepComplete]);
 
   const handleDissolving = useCallback(() => {
     setPreparationState(prev => ({
@@ -278,7 +278,7 @@ function OxalicAcidVirtualLab({
   }, [measurements.massWeighed, addResult]);
 
   const handleStepAction = useCallback((opts?: { skipAnimation?: boolean }) => {
-    switch (step.id) {
+    switch (stepNumber) {
       case 1:
         handleCalculation();
         break;
@@ -306,10 +306,10 @@ function OxalicAcidVirtualLab({
         handleFinalMixing();
         break;
     }
-  }, [step.id, handleCalculation, handleWeighing, handleDissolving, handleTransfer, handleTransferComplete, handleNearMark, handleFinalVolume, handleFinalMixing]);
+  }, [stepNumber, handleCalculation, handleWeighing, handleDissolving, handleTransfer, handleTransferComplete, handleNearMark, handleFinalVolume, handleFinalMixing]);
 
   useEffect(() => {
-    if (step.id !== 1) {
+    if (stepNumber !== 1) {
       stepOneAutoProgressedRef.current = false;
       return;
     }
@@ -343,10 +343,10 @@ function OxalicAcidVirtualLab({
     if (!allPlaced) {
       stepOneAutoProgressedRef.current = false;
     }
-  }, [equipmentPositions, step.id, onStepComplete, setMeasurements]);
+  }, [equipmentPositions, stepNumber, onStepComplete, setMeasurements]);
 
   useEffect(() => {
-    if (step.id !== 2) {
+    if (stepNumber !== 2) {
       stepTwoAlignedRef.current = false;
       return;
     }
@@ -451,10 +451,10 @@ function OxalicAcidVirtualLab({
         cancelAnimationFrame(frame);
       }
     };
-  }, [equipmentPositions, step.id, preparationState.oxalicAcidAdded, onStepComplete]);
+  }, [equipmentPositions, stepNumber, preparationState.oxalicAcidAdded, onStepComplete]);
 
   useEffect(() => {
-    if (step.id !== 2) {
+    if (stepNumber !== 2) {
       stepTwoAlignedRef.current = false;
       return;
     }
@@ -559,10 +559,10 @@ function OxalicAcidVirtualLab({
         cancelAnimationFrame(frame);
       }
     };
-  }, [equipmentPositions, step.id, preparationState.oxalicAcidAdded, onStepComplete]);
+  }, [equipmentPositions, stepNumber, preparationState.oxalicAcidAdded, onStepComplete]);
 
   useEffect(() => {
-    if (step.id !== 4) {
+    if (stepNumber !== 4) {
       stepFourAlignedRef.current = false;
       return;
     }
@@ -649,12 +649,12 @@ function OxalicAcidVirtualLab({
         cancelAnimationFrame(frame);
       }
     };
-  }, [equipmentPositions, step.id]);
+  }, [equipmentPositions, stepNumber]);
 
   // Listen for the workbench image shown events and auto-complete relevant steps
   useEffect(() => {
     const handlerForImage = () => {
-      if (step.id === 3) {
+      if (stepNumber === 3) {
         setPreparationState(prev => ({ ...prev, dissolved: true }));
         setTimeout(() => {
           try { onStepComplete(); } catch (e) {}
@@ -663,7 +663,7 @@ function OxalicAcidVirtualLab({
     };
 
     const handlerForBeaker = () => {
-      if (step.id === 5) {
+      if (stepNumber === 5) {
         // mark nearMark so step 5 can proceed and then auto-advance
         setPreparationState(prev => ({ ...prev, nearMark: true }));
         setTimeout(() => {
@@ -678,7 +678,7 @@ function OxalicAcidVirtualLab({
       window.removeEventListener('oxalic_image_shown', handlerForImage);
       window.removeEventListener('oxalic_beaker_image_shown', handlerForBeaker);
     };
-  }, [step.id, onStepComplete]);
+  }, [stepNumber, onStepComplete]);
 
 
   // Listen for a programmatic pour action specifically for step 7 (final mixing -> pour into flask)
@@ -736,17 +736,17 @@ function OxalicAcidVirtualLab({
   // Do NOT notify the parent so the equipment palette remains unchanged.
   const prevStepRef = useRef<number | null>(null);
   useEffect(() => {
-    if (prevStepRef.current === 3 && step.id === 4) {
+    if (prevStepRef.current === 3 && stepNumber === 4) {
       setEquipmentPositions(prev => prev.filter(pos => {
         const key = (pos.typeId ?? pos.id).toString().toLowerCase();
         return !key.includes("analytical_balance");
       }));
     }
-    prevStepRef.current = step.id;
-  }, [step.id]);
+    prevStepRef.current = stepNumber;
+  }, [stepNumber]);
 
   const canProceed = useCallback(() => {
-    switch (step.id) {
+    switch (stepNumber) {
       case 1:
         return measurements.targetMass > 0;
       case 2:
@@ -764,10 +764,10 @@ function OxalicAcidVirtualLab({
       default:
         return false;
     }
-  }, [step.id, measurements.targetMass, preparationState]);
+  }, [stepNumber, measurements.targetMass, preparationState]);
 
   useEffect(() => {
-    if (step.id === 1) {
+    if (stepNumber === 1) {
       return;
     }
     if (canProceed() && isActive) {
@@ -776,7 +776,7 @@ function OxalicAcidVirtualLab({
       }, 1000);
       return () => clearTimeout(timer);
     }
-  }, [canProceed, isActive, onStepComplete, step.id]);
+  }, [canProceed, isActive, onStepComplete, stepNumber]);
 
   return (
     <TooltipProvider>

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -187,7 +187,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
         setWashAnimation({ x: animX, y: animY, active: true });
 
         // If current step is 5, run a longer (6s) animation and then replace beaker image
-        const isStepFive = stepNumber === 5;
+        const isStepFive = stepNumber === 4;
         const duration = isStepFive ? 6000 : 1600;
 
         // After animation completes, actually add the water to the beaker's chemicals array
@@ -346,7 +346,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
 
       // If oxalic acid bottle was added during quantitative analysis step, show reminder and dispatch event
       try {
-        if (payload && payload.id === 'oxalic_acid' && stepNumber === 3) {
+        if (payload && payload.id === 'oxalic_acid' && stepNumber === 2) {
           showMessage('Click the calculator once to see the amount of acid required');
           try { window.dispatchEvent(new CustomEvent('oxalicCalculatorReminder')); } catch {}
         }
@@ -373,7 +373,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
           chemicals: [],
           typeId: data.id,
           name: data.name,
-          imageSrc: (stepNumber === 4 && (data.id === 'volumetric_flask' || (data.name || '').toLowerCase().includes('volumetric flask')))
+          imageSrc: (stepNumber === 3 && (data.id === 'volumetric_flask' || (data.name || '').toLowerCase().includes('volumetric flask')))
             ? 'https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2F1782add6aa7c40cc992b82016876895e?format=webp&width=800'
             : data.imageSrc,
         }
@@ -425,7 +425,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
           chemicals: [],
           typeId: eq.id,
           name: eq.name,
-          imageSrc: (stepNumber === 4 && eq.id === 'volumetric_flask')
+          imageSrc: (stepNumber === 3 && eq.id === 'volumetric_flask')
             ? 'https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2F1782add6aa7c40cc992b82016876895e?format=webp&width=800'
             : undefined,
         }
@@ -502,7 +502,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
         // acid from the weighing boat is mixed into the beaker for ~7 seconds, replace the
         // beaker image with the provided mixed-beaker image, then remove the stirrer and
         // weighing boat from the workspace and complete the step.
-        if (stepNumber === 6) {
+        if (stepNumber === 5) {
           // Find beaker and weighing boat positions
           const beaker = equipmentPositions.find(p => ((p.typeId ?? p.id) + '').toString().toLowerCase().includes('beaker'));
           const boat = equipmentPositions.find(p => ((p.typeId ?? p.id) + '').toString().toLowerCase().includes('weighing_boat') || ((p.typeId ?? p.id) + '').toString().toLowerCase().includes('weighing-boat'));
@@ -652,7 +652,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
           setEquipmentPositions(prev => prev.map(pos => pos.id === nearest.id ? { ...pos, chemicals: [] } : pos));
           setWashAnimation(null);
           try {
-            if (stepNumber === 4) {
+            if (stepNumber === 3) {
               // remove the wash bottle used for rinsing from the workbench
               setEquipmentPositions(prev => prev.filter(pos => pos.id !== bottle.id));
               // automatically trigger the step action for step 4 (transfer to flask)
@@ -1210,7 +1210,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                 )}
 
                 {/* Additional controls for Step 3: allow user to set amount of oxalic acid to add to weighing boat */}
-                {stepNumber === 3 && (
+                {stepNumber === 2 && (
                   <div className="space-y-3">
                     <div className="p-3 rounded-lg border-2 border-yellow-200 bg-gradient-to-r from-yellow-50 via-white to-yellow-25 shadow-md overflow-hidden">
                       {showAcidHint && (
@@ -1344,7 +1344,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                 )}
 
                 {/* Additional control for Step 7: pour into flask */}
-                {stepNumber === 7 && (
+                {stepNumber === 6 && (
                   <div className="space-y-2">
                     <Button
                       onClick={() => {

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/components/WorkBench.tsx
@@ -187,7 +187,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
         setWashAnimation({ x: animX, y: animY, active: true });
 
         // If current step is 5, run a longer (6s) animation and then replace beaker image
-        const isStepFive = step.id === 5;
+        const isStepFive = stepNumber === 5;
         const duration = isStepFive ? 6000 : 1600;
 
         // After animation completes, actually add the water to the beaker's chemicals array
@@ -245,7 +245,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
 
     window.addEventListener('addDistilledWater', addWaterHandler as EventListener);
     return () => window.removeEventListener('addDistilledWater', addWaterHandler as EventListener);
-  }, [equipmentPositions, setEquipmentPositions, showMessage, step.id]);
+  }, [equipmentPositions, setEquipmentPositions, showMessage, stepNumber]);
 
   useEffect(() => {
     if (isRunning) {
@@ -285,7 +285,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
 
     // support multiple drag data formats for robustness
     const raw = e.dataTransfer.getData("application/json") || e.dataTransfer.getData("equipment") || e.dataTransfer.getData("text/plain") || e.dataTransfer.getData("text/uri-list") || "";
-    const isStepOne = step.id === 1;
+    const isStepOne = stepNumber === 1;
     const allowedStepOneEquipment = new Set(["analytical_balance", "weighing_boat"]);
     const normalizeId = (value?: string) => (value ? value.toLowerCase().replace(/\s+/g, "_").replace(/-/g, "_") : "");
     const notThisStepMessage = "These equipments not necessary in this current step.";
@@ -346,7 +346,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
 
       // If oxalic acid bottle was added during quantitative analysis step, show reminder and dispatch event
       try {
-        if (payload && payload.id === 'oxalic_acid' && step.id === 3) {
+        if (payload && payload.id === 'oxalic_acid' && stepNumber === 3) {
           showMessage('Click the calculator once to see the amount of acid required');
           try { window.dispatchEvent(new CustomEvent('oxalicCalculatorReminder')); } catch {}
         }
@@ -373,7 +373,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
           chemicals: [],
           typeId: data.id,
           name: data.name,
-          imageSrc: (step.id === 4 && (data.id === 'volumetric_flask' || (data.name || '').toLowerCase().includes('volumetric flask')))
+          imageSrc: (stepNumber === 4 && (data.id === 'volumetric_flask' || (data.name || '').toLowerCase().includes('volumetric flask')))
             ? 'https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2F1782add6aa7c40cc992b82016876895e?format=webp&width=800'
             : data.imageSrc,
         }
@@ -425,7 +425,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
           chemicals: [],
           typeId: eq.id,
           name: eq.name,
-          imageSrc: (step.id === 4 && eq.id === 'volumetric_flask')
+          imageSrc: (stepNumber === 4 && eq.id === 'volumetric_flask')
             ? 'https://cdn.builder.io/api/v1/image/assets%2F3c8edf2c5e3b436684f709f440180093%2F1782add6aa7c40cc992b82016876895e?format=webp&width=800'
             : undefined,
         }
@@ -502,7 +502,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
         // acid from the weighing boat is mixed into the beaker for ~7 seconds, replace the
         // beaker image with the provided mixed-beaker image, then remove the stirrer and
         // weighing boat from the workspace and complete the step.
-        if (step.id === 6) {
+        if (stepNumber === 6) {
           // Find beaker and weighing boat positions
           const beaker = equipmentPositions.find(p => ((p.typeId ?? p.id) + '').toString().toLowerCase().includes('beaker'));
           const boat = equipmentPositions.find(p => ((p.typeId ?? p.id) + '').toString().toLowerCase().includes('weighing_boat') || ((p.typeId ?? p.id) + '').toString().toLowerCase().includes('weighing-boat'));
@@ -652,7 +652,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
           setEquipmentPositions(prev => prev.map(pos => pos.id === nearest.id ? { ...pos, chemicals: [] } : pos));
           setWashAnimation(null);
           try {
-            if (step.id === 4) {
+            if (stepNumber === 4) {
               // remove the wash bottle used for rinsing from the workbench
               setEquipmentPositions(prev => prev.filter(pos => pos.id !== bottle.id));
               // automatically trigger the step action for step 4 (transfer to flask)
@@ -670,7 +670,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
   // Auto-align beaker and wash bottle when step 4 is active and both are present
   const washAlignRef = useRef(false);
   useEffect(() => {
-    if (step.id !== 4) {
+    if (stepNumber !== 4) {
       washAlignRef.current = false;
       return;
     }
@@ -781,12 +781,12 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
 
     washAlignRef.current = true;
     try { showMessage("Click on the Rinse Beaker button to clean the beaker!", 'colorful'); } catch (e) {}
-  }, [equipmentPositions, step.id]);
+  }, [equipmentPositions, stepNumber]);
 
   // Alignment helper that forces the beaker and wash bottle into the step-4 layout.
   const alignBeakerAndWash = (force = false) => {
     try {
-      if (step.id !== 4) return;
+      if (stepNumber !== 4) return;
       const normalize = (value?: string) => (value ? value.toString().toLowerCase().replace(/\s+/g, "_").replace(/-/g, "_") : "");
       const beaker = equipmentPositions.find(p => normalize(p.typeId ?? p.id).includes('beaker'));
       const wash = equipmentPositions.find(p => normalize(p.typeId ?? p.id).includes('wash') || (p.typeId ?? p.id).toString().includes('wash_bottle') || (p.typeId ?? p.id).toString().includes('wash-bottle'));
@@ -878,7 +878,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
   };
 
   const getCurrentStepGuidance = () => {
-    switch (step.id) {
+    switch (stepNumber) {
       case 1:
         return "Use the calculator to determine the required mass of oxalic acid dihydrate";
       case 2:
@@ -915,7 +915,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
             <p className="text-sm text-gray-600 mt-1">
               {getCurrentStepGuidance()}
             </p>
-            {step.id === 1 && (
+            {stepNumber === 1 && (
               <p className="text-sm text-blue-700 font-medium mt-2">
                 Drag the analytical balance and weighing boat into the workbench.
               </p>
@@ -1042,7 +1042,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                     onRemove={handleEquipmentRemove}
                     preparationState={preparationState}
                     onAction={handleEquipmentAction}
-                    stepId={step.id}
+                    stepId={stepNumber}
                   />
                 );
               }
@@ -1071,7 +1071,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                     onRemove={handleEquipmentRemove}
                     preparationState={preparationState}
                     onAction={handleEquipmentAction}
-                    stepId={step.id}
+                    stepId={stepNumber}
                   />
                 );
               }
@@ -1092,7 +1092,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                     onRemove={handleEquipmentRemove}
                     preparationState={preparationState}
                     onAction={handleEquipmentAction}
-                    stepId={step.id}
+                    stepId={stepNumber}
                   />
                 );
               }
@@ -1210,7 +1210,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                 )}
 
                 {/* Additional controls for Step 3: allow user to set amount of oxalic acid to add to weighing boat */}
-                {step.id === 3 && (
+                {stepNumber === 3 && (
                   <div className="space-y-3">
                     <div className="p-3 rounded-lg border-2 border-yellow-200 bg-gradient-to-r from-yellow-50 via-white to-yellow-25 shadow-md overflow-hidden">
                       {showAcidHint && (
@@ -1344,7 +1344,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                 )}
 
                 {/* Additional control for Step 7: pour into flask */}
-                {step.id === 7 && (
+                {stepNumber === 7 && (
                   <div className="space-y-2">
                     <Button
                       onClick={() => {
@@ -1360,7 +1360,7 @@ export const WorkBench: React.FC<WorkBenchProps> = ({
                 )}
 
                 {/* default Undo/Reset when not in step 3 */}
-                {step.id !== 3 && (
+                {stepNumber !== 3 && (
                   <div className="space-y-2">
                     <Button onClick={onUndoStep} variant="outline" className="w-full bg-red-50 border-red-200 text-red-700 hover:bg-red-100" disabled={stepNumber <= 1}>
                       Undo Step {currentStepIndex}

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/data.ts
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/data.ts
@@ -35,15 +35,6 @@ const OxalicAcidData: OxalicAcidExperiment = {
     },
     {
       id: 2,
-      title: "Weigh Oxalic Acid",
-      description:
-        "drag the oxalic acid dihydrate and stirrer into the workspace",
-      duration: "8 minutes",
-      safety: "Handle with care, avoid skin contact",
-      completed: false,
-    },
-    {
-      id: 3,
       title: "calculate required amount of oxalic acid dihydrate",
       description:
         "Transfer the weighed oxalic acid to a 100 mL beaker. Add about 50 mL of distilled water and stir with a glass rod until completely dissolved.",
@@ -51,7 +42,7 @@ const OxalicAcidData: OxalicAcidExperiment = {
       completed: false,
     },
     {
-      id: 4,
+      id: 3,
       title: "Transfer to Volumetric Flask",
       description:
         "drag the beaker, wash bottle and volumetric flask into the workspace",
@@ -59,7 +50,7 @@ const OxalicAcidData: OxalicAcidExperiment = {
       completed: false,
     },
     {
-      id: 5,
+      id: 4,
       title: "add distilled water to beaker",
       description:
         "add distilled water to beaker",
@@ -67,7 +58,7 @@ const OxalicAcidData: OxalicAcidExperiment = {
       completed: false,
     },
     {
-      id: 6,
+      id: 5,
       title: "Mixing of acid with distilled water",
       description:
         "drag and drop the stirrer to the workspace and click on the stirrer to mix distilled water with the acid in the weighing boat",
@@ -75,7 +66,7 @@ const OxalicAcidData: OxalicAcidExperiment = {
       completed: false,
     },
     {
-      id: 7,
+      id: 6,
       title: "final mixing and result",
       description:
         "Cap the flask and invert it 20-25 times to ensure complete mixing. Calculate the exact molarity using the actual mass weighed.",

--- a/chemLab2-main/client/src/experiments/OxalicAcidStandardization/data.ts
+++ b/chemLab2-main/client/src/experiments/OxalicAcidStandardization/data.ts
@@ -9,7 +9,7 @@ const OxalicAcidData: OxalicAcidExperiment = {
   category: "Quantitative Analysis",
   difficulty: "Beginner",
   duration: 35,
-  steps: 7,
+  steps: 6,
   rating: 4.5,
   imageUrl:
     "https://images.unsplash.com/photo-1554475901-4538ddfbccc2?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",


### PR DESCRIPTION
## Purpose
The user requested to remove step 2 from the "Preparation of Standard Solution of Oxalic Acid" experiment and renumber the remaining steps sequentially. The goal was to eliminate the step gap and maintain a logical flow with 6 total steps instead of 7, ensuring users don't jump from step 1 directly to step 3.

## Code changes
- **Removed step 2** ("Weigh Oxalic Acid") from the experiment steps array in `data.ts`
- **Renumbered all subsequent steps** from step 3-7 to step 2-6 respectively
- **Updated step references** throughout the codebase:
  - Changed `step.id` references to `stepNumber` for consistency
  - Updated conditional logic that checked for specific step IDs (e.g., `step.id === 3` became `stepNumber === 2`)
  - Modified step-specific UI controls and guidance text
- **Reduced total step count** from 7 to 6 in the experiment metadata
- **Added auto-start timer** functionality when the component mounts

The changes ensure proper sequential numbering while maintaining all existing functionality and step-specific behaviors.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 123`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fb6362cb68ac41f2b86c0361bb068f6a/curry-zone)

👀 [Preview Link](https://fb6362cb68ac41f2b86c0361bb068f6a-curry-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fb6362cb68ac41f2b86c0361bb068f6a</projectId>-->
<!--<branchName>curry-zone</branchName>-->